### PR TITLE
Install with Bun, and stop reinstalling on every container start

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# Dependencies
+node_modules/
+**/node_modules/
+
+# Version control
+.git/
+.gitignore
+
+# Project tooling / planning artifacts
+.superpowers/
+
+# Test artifacts
+test-results/
+**/test-results/
+coverage/
+**/coverage/
+
+# Build outputs
+dist/
+**/dist/
+build/
+**/build/
+.svelte-kit/
+**/.svelte-kit/
+*.tsbuildinfo
+
+# Runtime data
+*.db
+*.db-journal
+**/*.db
+**/*.db-journal
+
+# Environment files
+.env
+.env.local
+.env.*.local
+**/.env
+**/.env.local
+**/.env.*.local
+
+# IDE / OS
+.vscode/
+.idea/
+.DS_Store
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -109,12 +109,25 @@ L'application sera disponible sur:
 - Frontend: http://localhost:5173
 - Backend API: http://localhost:3000
 
-**Après avoir ajouté/modifié une dépendance** (`package.json` racine, `backend/package.json` ou `frontend/package.json`), un simple redémarrage des conteneurs ne suffit plus : les dépendances sont installées une seule fois, à la construction de l'image, pas à chaque démarrage. Il faut reconstruire l'image et recréer le volume `node_modules` qu'elle avait initialisé :
+**Après avoir ajouté/modifié une dépendance** (`package.json` racine, `backend/package.json` ou `frontend/package.json`), un simple redémarrage des conteneurs ne suffit plus : les dépendances sont installées une seule fois, à la construction de l'image, pas à chaque démarrage. Le volume qui les porte n'est pas traité pareil des deux côtés :
+
+- côté **backend**, `node_modules` est un volume **nommé** (`backend-node-modules`) : il
+  survit même à `docker compose up --build`, il faut le supprimer explicitement ;
+- côté **frontend**, `node_modules` est un volume **anonyme** : par défaut, Compose
+  réutilise les données de l'ancien conteneur plutôt que de les régénérer depuis
+  l'image reconstruite — il faut forcer son renouvellement.
 
 ```bash
-docker compose down -v
-docker compose up --build -d
+docker compose up --build -d --renew-anon-volumes   # reconstruit les images, régénère le volume anonyme du frontend
+
+docker compose rm -sf backend                       # côté backend seulement : le volume nommé doit être supprimé à part
+docker volume rm psnes_backend-node-modules
+docker compose up -d backend
 ```
+
+⚠️ Ne pas utiliser `docker compose down -v` pour ça : cette commande supprime **tous**
+les volumes nommés du projet, y compris la base SQLite de dev, les saves, les avatars
+et les données Redis.
 
 ## 🎯 User Journey
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ L'application sera disponible sur:
 - Frontend: http://localhost:5173
 - Backend API: http://localhost:3000
 
+**Après avoir ajouté/modifié une dépendance** (`package.json` racine, `backend/package.json` ou `frontend/package.json`), un simple redémarrage des conteneurs ne suffit plus : les dépendances sont installées une seule fois, à la construction de l'image, pas à chaque démarrage. Il faut reconstruire l'image et recréer le volume `node_modules` qu'elle avait initialisé :
+
+```bash
+docker compose down -v
+docker compose up --build -d
+```
+
 ## 🎯 User Journey
 
 1. **Connexion** - Se connecter avec Google

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,13 +3,17 @@
 ##
 FROM node:20 AS prod-deps
 
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+
 WORKDIR /app
 ENV NODE_ENV=build
 
-COPY backend/package*.json ./
-COPY package-lock.json ./
+COPY package.json ./
+COPY backend/package.json ./backend/package.json
+COPY frontend/package.json ./frontend/package.json
+COPY bun.lock ./
 
-RUN npm ci --omit=dev --prefer-offline
+RUN bun install --production --frozen-lockfile --filter=./backend
 
 
 ##
@@ -29,19 +33,19 @@ RUN apt-get update && apt-get install -y \
     librsvg2-dev
 
 # Copy package files and install ALL dependencies (needed for build)
-RUN npm ci --prefer-offline
+RUN bun install --frozen-lockfile --filter=./backend
 
 # Copy source code and prisma schema
-COPY backend/prisma ./prisma
+COPY backend/prisma ./backend/prisma
 
 # Generate Prisma client
-RUN npx prisma generate
+RUN npx prisma generate --schema=backend/prisma/schema.prisma
 
-COPY backend/src ./src
-COPY backend/tsconfig.json ./
+COPY backend/src ./backend/src
+COPY backend/tsconfig.json ./backend/tsconfig.json
 
 # Build TypeScript to JavaScript
-RUN npm run build
+RUN bun run --filter=./backend build
 
 
 ##
@@ -68,11 +72,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=prod-deps /app/node_modules ./node_modules
 
 # Copy Prisma schema and runtime dependencies from builder stage
-COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/backend/prisma ./prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 
 # Copy built application from builder
-COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/backend/dist ./dist
 
 # Create directories for runtime data (will be mounted as volumes)
 RUN mkdir -p roms saves data avatars metadata && \

--- a/backend/dev.Dockerfile
+++ b/backend/dev.Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20
 
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+
 WORKDIR /app
 
 # Install native dependencies for canvas (cached as a layer)
@@ -9,8 +11,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy package files and install dependencies (cached until package.json changes)
-COPY backend/package*.json ./
-RUN npm install
+COPY backend/package.json ./
+COPY bun.lock ./
+RUN bun install
 
 # Copy prisma schema and generate client (cached until schema changes)
 COPY backend/prisma ./prisma

--- a/backend/dev.Dockerfile
+++ b/backend/dev.Dockerfile
@@ -10,10 +10,15 @@ RUN apt-get update && apt-get install -y \
     libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy package files and install dependencies (cached until package.json changes)
-COPY backend/package.json ./
+# Copy package files and install dependencies (cached until package.json changes).
+# The full workspace shape (root + both member manifests) is required: bun.lock
+# describes a 3-workspace root, and Bun discards/re-resolves against any context
+# that doesn't match that shape, silently floating every version.
+COPY package.json ./
+COPY backend/package.json ./backend/package.json
+COPY frontend/package.json ./frontend/package.json
 COPY bun.lock ./
-RUN bun install
+RUN bun install --filter=./backend
 
 # Copy prisma schema and generate client (cached until schema changes)
 COPY backend/prisma ./prisma

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,946 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "psnes",
+      "devDependencies": {
+        "@playwright/test": "^1.57.0",
+        "@types/simple-peer": "^9.11.9",
+        "socket.io-client": "^4.7.2",
+        "tsx": "^4.20.6",
+      },
+    },
+    "backend": {
+      "name": "psnes-backend",
+      "version": "1.0.0",
+      "dependencies": {
+        "@prisma/client": "^5.22.0",
+        "compression": "^1.8.1",
+        "connect-redis": "^7.1.1",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.1",
+        "engine.io": "^6.6.9",
+        "express": "^4.18.2",
+        "express-session": "^1.18.0",
+        "helmet": "^7.1.0",
+        "passport": "^0.7.0",
+        "passport-google-oauth20": "^2.0.0",
+        "pino": "^10.1.0",
+        "pino-pretty": "^13.1.2",
+        "redis": "^4.6.13",
+        "socket.io": "^4.7.2",
+      },
+      "devDependencies": {
+        "@types/compression": "^1.8.1",
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
+        "@types/express-session": "^1.17.10",
+        "@types/node": "^20.11.16",
+        "@types/passport": "^1.0.16",
+        "@types/passport-google-oauth20": "^2.0.14",
+        "prisma": "^5.22.0",
+        "tsx": "^4.7.1",
+        "typescript": "^5.3.3",
+      },
+    },
+    "frontend": {
+      "name": "psnes-frontend",
+      "version": "1.0.0",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "@types/ini": "^4.1.1",
+        "@types/path-browserify": "^1.0.3",
+        "buffer": "^5.7.1",
+        "events": "^3.3.0",
+        "ini": "^1.3.8",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "simple-peer": "^9.11.1",
+        "socket.io-client": "^4.7.2",
+      },
+      "devDependencies": {
+        "@sveltejs/adapter-static": "^3.0.1",
+        "@sveltejs/kit": "^2.5.0",
+        "@sveltejs/vite-plugin-svelte": "^3.0.2",
+        "@types/simple-peer": "^9.11.9",
+        "svelte": "^4.2.12",
+        "svelte-check": "^3.6.4",
+        "tslib": "^2.6.2",
+        "typescript": "^5.3.3",
+        "vite": "^5.1.4",
+      },
+    },
+  },
+  "packages": {
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.28.5", "", {}, "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA=="],
+
+    "@babel/core": ["@babel/core@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.28.3", "@babel/helpers": "^7.28.4", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw=="],
+
+    "@babel/generator": ["@babel/generator@7.28.5", "", { "dependencies": { "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.27.2", "", { "dependencies": { "@babel/compat-data": "^7.27.2", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.3", "", { "dependencies": { "@babel/helper-module-imports": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1", "@babel/traverse": "^7.28.3" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.28.4", "", { "dependencies": { "@babel/template": "^7.27.2", "@babel/types": "^7.28.4" } }, "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w=="],
+
+    "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
+
+    "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
+
+    "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
+
+    "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/source-map": ["@jridgewell/source-map@0.3.11", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25" } }, "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@prisma/client": ["@prisma/client@5.22.0", "", { "peerDependencies": { "prisma": "*" } }, "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA=="],
+
+    "@prisma/debug": ["@prisma/debug@5.22.0", "", {}, "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ=="],
+
+    "@prisma/engines": ["@prisma/engines@5.22.0", "", { "dependencies": { "@prisma/debug": "5.22.0", "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2", "@prisma/fetch-engine": "5.22.0", "@prisma/get-platform": "5.22.0" } }, "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA=="],
+
+    "@prisma/engines-version": ["@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2", "", {}, "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ=="],
+
+    "@prisma/fetch-engine": ["@prisma/fetch-engine@5.22.0", "", { "dependencies": { "@prisma/debug": "5.22.0", "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2", "@prisma/get-platform": "5.22.0" } }, "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA=="],
+
+    "@prisma/get-platform": ["@prisma/get-platform@5.22.0", "", { "dependencies": { "@prisma/debug": "5.22.0" } }, "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q=="],
+
+    "@redis/bloom": ["@redis/bloom@1.2.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg=="],
+
+    "@redis/client": ["@redis/client@1.6.1", "", { "dependencies": { "cluster-key-slot": "1.1.2", "generic-pool": "3.9.0", "yallist": "4.0.0" } }, "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw=="],
+
+    "@redis/graph": ["@redis/graph@1.1.1", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw=="],
+
+    "@redis/json": ["@redis/json@1.0.7", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ=="],
+
+    "@redis/search": ["@redis/search@1.2.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw=="],
+
+    "@redis/time-series": ["@redis/time-series@1.1.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.53.2", "", { "os": "android", "cpu": "arm" }, "sha512-yDPzwsgiFO26RJA4nZo8I+xqzh7sJTZIWQOxn+/XOdPE31lAvLIYCKqjV+lNH/vxE2L2iH3plKxDCRK6i+CwhA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.53.2", "", { "os": "android", "cpu": "arm64" }, "sha512-k8FontTxIE7b0/OGKeSN5B6j25EuppBcWM33Z19JoVT7UTXFSo3D9CdU39wGTeb29NO3XxpMNauh09B+Ibw+9g=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.53.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-A6s4gJpomNBtJ2yioj8bflM2oogDwzUiMl2yNJ2v9E7++sHrSrsQ29fOfn5DM/iCzpWcebNYEdXpaK4tr2RhfQ=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.53.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-e6XqVmXlHrBlG56obu9gDRPW3O3hLxpwHpLsBJvuI8qqnsrtSZ9ERoWUXtPOkY8c78WghyPHZdmPhHLWNdAGEw=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.53.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-v0E9lJW8VsrwPux5Qe5CwmH/CF/2mQs6xU1MF3nmUxmZUCHazCjLgYvToOk+YuuUqLQBio1qkkREhxhc656ViA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.53.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ClAmAPx3ZCHtp6ysl4XEhWU69GUB1D+s7G9YjHGhIGCSrsg00nEGRRZHmINYxkdoJehde8VIsDC5t9C0gb6yqA=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.53.2", "", { "os": "linux", "cpu": "arm" }, "sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.53.2", "", { "os": "linux", "cpu": "arm" }, "sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.53.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.53.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.53.2", "", { "os": "linux", "cpu": "none" }, "sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.53.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.53.2", "", { "os": "linux", "cpu": "none" }, "sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.53.2", "", { "os": "linux", "cpu": "none" }, "sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.53.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.53.2", "", { "os": "linux", "cpu": "x64" }, "sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.53.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.53.2", "", { "os": "none", "cpu": "arm64" }, "sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.53.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-IlbHFYc/pQCgew/d5fslcy1KEaYVCJ44G8pajugd8VoOEI8ODhtb/j8XMhLpwHCMB3yk2J07ctup10gpw2nyMA=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.53.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-lNlPEGgdUfSzdCWU176ku/dQRnA7W+Gp8d+cWv73jYrb8uT7HTVVxq62DUYxjbaByuf1Yk0RIIAbDzp+CnOTFg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.53.2", "", { "os": "win32", "cpu": "x64" }, "sha512-S6YojNVrHybQis2lYov1sd+uj7K0Q05NxHcGktuMMdIQ2VixGwAfbJ23NnlvvVV1bdpR2m5MsNBViHJKcA4ADw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.2", "", { "os": "win32", "cpu": "x64" }, "sha512-k+/Rkcyx//P6fetPoLMb8pBeqJBNGx81uuf7iljX9++yNBVRDQgD04L+SVXmXmh5ZP4/WOp4mWF0kmi06PW2tA=="],
+
+    "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.7", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-znp1A/Y1Jj4l/Zy7PX5DZKBE0ZNY+5QBngiE21NJkfSTyzzC5iKNWOtwFXKtIrn7MXEFBck4jD95iBNkGjK92Q=="],
+
+    "@sveltejs/adapter-static": ["@sveltejs/adapter-static@3.0.10", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew=="],
+
+    "@sveltejs/kit": ["@sveltejs/kit@2.48.5", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.3.2", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "sade": "^1.8.1", "set-cookie-parser": "^2.6.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["@opentelemetry/api"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-/rnwfSWS3qwUSzvHynUTORF9xSJi7PCR9yXkxUOnRrNqyKmCmh3FPHH+E9BbgqxXfTevGXBqgnlh9kMb+9T5XA=="],
+
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@3.1.2", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0", "debug": "^4.3.4", "deepmerge": "^4.3.1", "kleur": "^4.1.5", "magic-string": "^0.30.10", "svelte-hmr": "^0.16.0", "vitefu": "^0.2.5" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "vite": "^5.0.0" } }, "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA=="],
+
+    "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@2.1.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^3.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "vite": "^5.0.0" } }, "sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg=="],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/compression": ["@types/compression@1.8.1", "", { "dependencies": { "@types/express": "*", "@types/node": "*" } }, "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
+
+    "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
+
+    "@types/emscripten": ["@types/emscripten@1.41.5", "", {}, "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/express": ["@types/express@4.17.25", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "^1" } }, "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.7", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg=="],
+
+    "@types/express-session": ["@types/express-session@1.18.2", "", { "dependencies": { "@types/express": "*" } }, "sha512-k+I0BxwVXsnEU2hV77cCobC08kIsn4y44C3gC0b46uxZVMaXA04lSPgRLR/bSL2w0t0ShJiG8o4jPzRG/nscFg=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/ini": ["@types/ini@4.1.1", "", {}, "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg=="],
+
+    "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
+
+    "@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "@types/oauth": ["@types/oauth@0.9.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-H9TRCVKBNOhZZmyHLqFt9drPM9l+ShWiqqJijU1B8P3DX3ub84NjxDuy+Hjrz+fEca5Kwip3qPMKNyiLgNJtIA=="],
+
+    "@types/passport": ["@types/passport@1.0.17", "", { "dependencies": { "@types/express": "*" } }, "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg=="],
+
+    "@types/passport-google-oauth20": ["@types/passport-google-oauth20@2.0.17", "", { "dependencies": { "@types/express": "*", "@types/passport": "*", "@types/passport-oauth2": "*" } }, "sha512-MHNOd2l7gOTCn3iS+wInPQMiukliAUvMpODO3VlXxOiwNEMSyzV7UNvAdqxSN872o8OXx1SqPDVT6tLW74AtqQ=="],
+
+    "@types/passport-oauth2": ["@types/passport-oauth2@1.8.0", "", { "dependencies": { "@types/express": "*", "@types/oauth": "*", "@types/passport": "*" } }, "sha512-6//z+4orIOy/g3zx17HyQ71GSRK4bs7Sb+zFasRoc2xzlv7ZCJ+vkDBYFci8U6HY+or6Zy7ajf4mz4rK7nsWJQ=="],
+
+    "@types/path-browserify": ["@types/path-browserify@1.0.3", "", {}, "sha512-ZmHivEbNCBtAfcrFeBCiTjdIc2dey0l7oCGNGpSuRTy8jP6UVND7oUowlvDujBy8r2Hoa8bfFUOCiPWfmtkfxw=="],
+
+    "@types/pug": ["@types/pug@2.0.10", "", {}, "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA=="],
+
+    "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
+
+    "@types/simple-peer": ["@types/simple-peer@9.11.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-6Gdl7TSS5oh9nuwKD4Pl8cSmaxWycYeZz9HLnJBNvIwWjZuGVsmHe9RwW3+9RxfhC1aIR9Z83DvaJoMw6rhkbg=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
+    "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "base64id": ["base64id@2.0.0", "", {}, "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="],
+
+    "base64url": ["base64url@3.0.1", "", {}, "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.8.29", "", { "bin": "dist/cli.js" }, "sha512-sXdt2elaVnhpDNRDz+1BDx1JQoJRuNk7oVlAlbGiFkLikHCAQiccexF/9e91zVi6RCgqspl04aP+6Cnl9zRLrA=="],
+
+    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "body-parser": ["body-parser@1.20.6", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.15.1", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g=="],
+
+    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.0", "", { "dependencies": { "baseline-browser-mapping": "^2.8.25", "caniuse-lite": "^1.0.30001754", "electron-to-chromium": "^1.5.249", "node-releases": "^2.0.27", "update-browserslist-db": "^1.1.4" }, "bin": "cli.js" }, "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001755", "", {}, "sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA=="],
+
+    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
+    "code-red": ["code-red@1.0.4", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15", "@types/estree": "^1.0.1", "acorn": "^8.10.0", "estree-walker": "^3.0.3", "periscopic": "^3.1.0" } }, "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "compressible": ["compressible@2.0.18", "", { "dependencies": { "mime-db": ">= 1.43.0 < 2" } }, "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg=="],
+
+    "compression": ["compression@1.8.1", "", { "dependencies": { "bytes": "3.1.2", "compressible": "~2.0.18", "debug": "2.6.9", "negotiator": "~0.6.4", "on-headers": "~1.1.0", "safe-buffer": "5.2.1", "vary": "~1.1.2" } }, "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "connect-redis": ["connect-redis@7.1.1", "", { "peerDependencies": { "express-session": ">=1" } }, "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ=="],
+
+    "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
+
+    "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
+
+    "css-tree": ["css-tree@2.3.1", "", { "dependencies": { "mdn-data": "2.0.30", "source-map-js": "^1.0.1" } }, "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
+    "debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
+
+    "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
+
+    "devalue": ["devalue@5.5.0", "", {}, "sha512-69sM5yrHfFLJt0AZ9QqZXGCPfJ7fQjvpln3Rq5+PS03LD32Ost1Q9N+eEnaQwGRIriKkMImXD56ocjQmfjbV3w=="],
+
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.255", "", {}, "sha512-Z9oIp4HrFF/cZkDPMpz2XSuVpc1THDpT4dlmATFlJUIBVCy9Vap5/rIXsASP1CscBacBqhabwh8vLctqBwEerQ=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "engine.io": ["engine.io@6.6.9", "", { "dependencies": { "@types/cors": "^2.8.12", "@types/node": ">=10.0.0", "@types/ws": "^8.5.12", "accepts": "~1.3.4", "base64id": "2.0.0", "cookie": "~0.7.2", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.21.0" } }, "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg=="],
+
+    "engine.io-client": ["engine.io-client@6.6.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.3.1", "engine.io-parser": "~5.2.1", "ws": "~8.17.1", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w=="],
+
+    "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
+
+    "err-code": ["err-code@3.0.1", "", {}, "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es6-promise": ["es6-promise@3.3.1", "", {}, "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": "bin/esbuild" }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "express": ["express@4.22.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.5", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.15.1", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q=="],
+
+    "express-session": ["express-session@1.18.2", "", { "dependencies": { "cookie": "0.7.2", "cookie-signature": "1.0.7", "debug": "2.6.9", "depd": "~2.0.0", "on-headers": "~1.1.0", "parseurl": "~1.3.3", "safe-buffer": "5.2.1", "uid-safe": "~2.1.5" } }, "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A=="],
+
+    "fast-copy": ["fast-copy@3.0.2", "", {}, "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "finalhandler": ["finalhandler@1.3.1", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "2.4.1", "parseurl": "~1.3.3", "statuses": "2.0.1", "unpipe": "~1.0.0" } }, "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "generic-pool": ["generic-pool@3.9.0", "", {}, "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-browser-rtc": ["get-browser-rtc@1.1.0", "", {}, "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "helmet": ["helmet@7.2.0", "", {}, "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
+    "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
+
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": "bin/jsesc" }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdn-data": ["mdn-data@2.0.30", "", {}, "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="],
+
+    "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
+
+    "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
+
+    "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
+
+    "mime": ["mime@1.6.0", "", { "bin": "cli.js" }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": "bin/cmd.js" }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+
+    "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "oauth": ["oauth@0.10.2", "", {}, "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "on-headers": ["on-headers@1.1.0", "", {}, "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "passport": ["passport@0.7.0", "", { "dependencies": { "passport-strategy": "1.x.x", "pause": "0.0.1", "utils-merge": "^1.0.1" } }, "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ=="],
+
+    "passport-google-oauth20": ["passport-google-oauth20@2.0.0", "", { "dependencies": { "passport-oauth2": "1.x.x" } }, "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ=="],
+
+    "passport-oauth2": ["passport-oauth2@1.8.0", "", { "dependencies": { "base64url": "3.x.x", "oauth": "0.10.x", "passport-strategy": "1.x.x", "uid2": "0.0.x", "utils-merge": "1.x.x" } }, "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA=="],
+
+    "passport-strategy": ["passport-strategy@1.0.0", "", {}, "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "path-to-regexp": ["path-to-regexp@0.1.13", "", {}, "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="],
+
+    "pause": ["pause@0.0.1", "", {}, "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="],
+
+    "periscopic": ["periscopic@3.1.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^3.0.0", "is-reference": "^3.0.0" } }, "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "pino": ["pino@10.1.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": "bin.js" }, "sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-pretty": ["pino-pretty@13.1.2", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^3.0.2", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": "bin.js" }, "sha512-3cN0tCakkT4f3zo9RXDIhy6GTvtYD6bK4CRBLN9j3E/ePqN1tugAXD5rGVfoChW6s0hiek+eyYlLNqc/BG7vBQ=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
+
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": "cli.js" }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": "cli.js" }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "prisma": ["prisma@5.22.0", "", { "dependencies": { "@prisma/engines": "5.22.0" }, "optionalDependencies": { "fsevents": "2.3.3" }, "bin": "build/index.js" }, "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "psnes-backend": ["psnes-backend@workspace:backend"],
+
+    "psnes-frontend": ["psnes-frontend@workspace:frontend"],
+
+    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "random-bytes": ["random-bytes@1.0.0", "", {}, "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ=="],
+
+    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "redis": ["redis@4.7.1", "", { "dependencies": { "@redis/bloom": "1.2.0", "@redis/client": "1.6.1", "@redis/graph": "1.1.1", "@redis/json": "1.0.7", "@redis/search": "1.2.0", "@redis/time-series": "1.1.0" } }, "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "rimraf": ["rimraf@2.7.1", "", { "dependencies": { "glob": "^7.1.3" }, "bin": "bin.js" }, "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w=="],
+
+    "rollup": ["rollup@4.53.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.53.2", "@rollup/rollup-android-arm64": "4.53.2", "@rollup/rollup-darwin-arm64": "4.53.2", "@rollup/rollup-darwin-x64": "4.53.2", "@rollup/rollup-freebsd-arm64": "4.53.2", "@rollup/rollup-freebsd-x64": "4.53.2", "@rollup/rollup-linux-arm-gnueabihf": "4.53.2", "@rollup/rollup-linux-arm-musleabihf": "4.53.2", "@rollup/rollup-linux-arm64-gnu": "4.53.2", "@rollup/rollup-linux-arm64-musl": "4.53.2", "@rollup/rollup-linux-loong64-gnu": "4.53.2", "@rollup/rollup-linux-ppc64-gnu": "4.53.2", "@rollup/rollup-linux-riscv64-gnu": "4.53.2", "@rollup/rollup-linux-riscv64-musl": "4.53.2", "@rollup/rollup-linux-s390x-gnu": "4.53.2", "@rollup/rollup-linux-x64-gnu": "4.53.2", "@rollup/rollup-linux-x64-musl": "4.53.2", "@rollup/rollup-openharmony-arm64": "4.53.2", "@rollup/rollup-win32-arm64-msvc": "4.53.2", "@rollup/rollup-win32-ia32-msvc": "4.53.2", "@rollup/rollup-win32-x64-gnu": "4.53.2", "@rollup/rollup-win32-x64-msvc": "4.53.2", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g=="],
+
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sander": ["sander@0.5.1", "", { "dependencies": { "es6-promise": "^3.1.2", "graceful-fs": "^4.1.3", "mkdirp": "^0.5.1", "rimraf": "^2.5.2" } }, "sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "send": ["send@0.19.0", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "0.5.2", "http-errors": "2.0.0", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "2.4.1", "range-parser": "~1.2.1", "statuses": "2.0.1" } }, "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw=="],
+
+    "serve-static": ["serve-static@1.16.2", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "0.19.0" } }, "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "simple-peer": ["simple-peer@9.11.1", "", { "dependencies": { "buffer": "^6.0.3", "debug": "^4.3.2", "err-code": "^3.0.1", "get-browser-rtc": "^1.1.0", "queue-microtask": "^1.2.3", "randombytes": "^2.1.0", "readable-stream": "^3.6.0" } }, "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw=="],
+
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "socket.io": ["socket.io@4.8.1", "", { "dependencies": { "accepts": "~1.3.4", "base64id": "~2.0.0", "cors": "~2.8.5", "debug": "~4.3.2", "engine.io": "~6.6.0", "socket.io-adapter": "~2.5.2", "socket.io-parser": "~4.2.4" } }, "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg=="],
+
+    "socket.io-adapter": ["socket.io-adapter@2.5.8", "", { "dependencies": { "debug": "~4.4.1", "ws": "~8.21.0" } }, "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw=="],
+
+    "socket.io-client": ["socket.io-client@4.8.1", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.3.2", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ=="],
+
+    "socket.io-parser": ["socket.io-parser@4.2.7", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg=="],
+
+    "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
+
+    "sorcery": ["sorcery@0.11.1", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.14", "buffer-crc32": "^1.0.0", "minimist": "^1.2.0", "sander": "^0.5.0" }, "bin": "bin/sorcery" }, "sha512-o7npfeJE6wi6J9l0/5LKshFzZ2rMatRiCDwYeDQaOzqdzRJwALhX7mk/A/ecg6wjMu7wdZbmXfD2S/vpOg0bdQ=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "svelte": ["svelte@4.2.20", "", { "dependencies": { "@ampproject/remapping": "^2.2.1", "@jridgewell/sourcemap-codec": "^1.4.15", "@jridgewell/trace-mapping": "^0.3.18", "@types/estree": "^1.0.1", "acorn": "^8.9.0", "aria-query": "^5.3.0", "axobject-query": "^4.0.0", "code-red": "^1.0.3", "css-tree": "^2.3.1", "estree-walker": "^3.0.3", "is-reference": "^3.0.1", "locate-character": "^3.0.0", "magic-string": "^0.30.4", "periscopic": "^3.1.0" } }, "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q=="],
+
+    "svelte-check": ["svelte-check@3.8.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.17", "chokidar": "^3.4.1", "picocolors": "^1.0.0", "sade": "^1.7.4", "svelte-preprocess": "^5.1.3", "typescript": "^5.0.3" }, "peerDependencies": { "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0" }, "bin": "bin/svelte-check" }, "sha512-ij0u4Lw/sOTREP13BdWZjiXD/BlHE6/e2e34XzmVmsp5IN4kVa3PWP65NM32JAgwjZlwBg/+JtiNV1MM8khu0Q=="],
+
+    "svelte-hmr": ["svelte-hmr@0.16.0", "", { "peerDependencies": { "svelte": "^3.19.0 || ^4.0.0" } }, "sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA=="],
+
+    "svelte-preprocess": ["svelte-preprocess@5.1.4", "", { "dependencies": { "@types/pug": "^2.0.6", "detect-indent": "^6.1.0", "magic-string": "^0.30.5", "sorcery": "^0.11.0", "strip-indent": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.10.2", "coffeescript": "^2.5.1", "less": "^3.11.3 || ^4.0.0", "postcss": "^7 || ^8", "postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0", "pug": "^3.0.0", "sass": "^1.26.8", "stylus": "^0.55.0", "sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0", "svelte": "^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0", "typescript": ">=3.9.5 || ^4.0.0 || ^5.0.0" }, "optionalPeers": ["coffeescript", "less", "postcss-load-config", "pug", "sass", "stylus", "sugarss"] }, "sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA=="],
+
+    "terser": ["terser@5.36.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.8.2", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": "bin/terser" }, "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w=="],
+
+    "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.20.6", "", { "dependencies": { "esbuild": "~0.25.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg=="],
+
+    "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uid-safe": ["uid-safe@2.1.5", "", { "dependencies": { "random-bytes": "~1.0.0" } }, "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA=="],
+
+    "uid2": ["uid2@0.0.4", "", {}, "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.1.4", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss"], "bin": "bin/vite.js" }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vitefu": ["vitefu@0.2.5", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0" } }, "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
+    "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
+
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/traverse/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@sveltejs/kit/cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
+    "@sveltejs/vite-plugin-svelte/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@sveltejs/vite-plugin-svelte-inspector/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
+
+    "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "body-parser/http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "code-red/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "engine.io/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "engine.io-client/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
+
+    "engine.io-client/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
+    "express/cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
+
+    "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "express-session/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "express-session/cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
+
+    "express-session/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "periscopic/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "periscopic/is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "raw-body/http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
+    "send/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "simple-peer/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "simple-peer/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "socket.io/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
+
+    "socket.io-adapter/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "socket.io-adapter/ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
+    "socket.io-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": "bin/esbuild" }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "@babel/core/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "@babel/traverse/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "@sveltejs/vite-plugin-svelte-inspector/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "@sveltejs/vite-plugin-svelte/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "body-parser/http-errors/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "engine.io-client/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "engine.io/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "express-session/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "raw-body/http-errors/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "simple-peer/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "socket.io-adapter/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "socket.io-parser/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "socket.io/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+  }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,8 +48,8 @@ services:
 
   frontend:
     build:
-      context: ./frontend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: frontend/Dockerfile
     ports:
       - "5173:80"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,10 +44,15 @@ services:
       - backend-avatars:/app/avatars
       - ./backend/data/snes-metadata.json:/app/metadata/snes-metadata.json:ro
     # Dependencies are installed once at image build time (backend/dev.Dockerfile),
-    # not on every container start. After changing backend/package.json (or the root
-    # package.json / bun.lock), the image and the backend-node-modules volume are both
-    # stale: `docker compose down -v && docker compose up --build -d` picks up the change.
-    # Restarting the container alone will not.
+    # not on every container start. backend-node-modules is a NAMED volume, so it
+    # survives both a plain restart and `docker compose up --build`. After changing
+    # backend/package.json (or the root package.json / bun.lock), drop it explicitly
+    # (do NOT `down -v`, which also wipes the dev database, saves, avatars and redis
+    # data — see the frontend service below for its own, different gotcha):
+    #   docker compose up --build -d
+    #   docker compose rm -sf backend
+    #   docker volume rm psnes_backend-node-modules
+    #   docker compose up -d backend
     command: sh -c "npx prisma generate && npm run dev"
     depends_on:
       - redis
@@ -66,9 +71,14 @@ services:
     environment:
       - VITE_API_URL=http://localhost:3000
       - BACKEND_URL=http://backend:3000
-    # Same as the backend above: dependencies come from the image build, not from an
-    # install at start. After changing frontend/package.json (or the root package.json /
-    # bun.lock): `docker compose down -v && docker compose up --build -d`.
+    # Dependencies come from the image build (frontend/dev.Dockerfile), not from an
+    # install at start. Its /app/node_modules above is an ANONYMOUS volume — by
+    # default Compose carries an anonymous volume's *data* over from the old
+    # container to the new one on recreation, so a plain `--build` alone does NOT
+    # pick up a changed frontend/package.json (or root package.json / bun.lock):
+    # verified, it silently keeps the stale packages. Force it to reseed from the
+    # freshly built image instead:
+    #   docker compose up --build -d --renew-anon-volumes
     command: sh -c "npm run dev -- --host"
     depends_on:
       - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,19 @@ services:
       - backend-saves:/app/saves
       - backend-avatars:/app/avatars
       - ./backend/data/snes-metadata.json:/app/metadata/snes-metadata.json:ro
-    command: sh -c "npm install && npx prisma generate && npm run dev"
+    # Dependencies are installed once at image build time (backend/dev.Dockerfile),
+    # not on every container start. After changing backend/package.json (or the root
+    # package.json / bun.lock), the image and the backend-node-modules volume are both
+    # stale: `docker compose down -v && docker compose up --build -d` picks up the change.
+    # Restarting the container alone will not.
+    command: sh -c "npx prisma generate && npm run dev"
     depends_on:
       - redis
 
   frontend:
-    image: node:20-alpine
+    build:
+      context: .
+      dockerfile: frontend/dev.Dockerfile
     working_dir: /app
     ports:
       - "5173:5173"
@@ -59,7 +66,10 @@ services:
     environment:
       - VITE_API_URL=http://localhost:3000
       - BACKEND_URL=http://backend:3000
-    command: sh -c "npm install && npm run dev -- --host"
+    # Same as the backend above: dependencies come from the image build, not from an
+    # install at start. After changing frontend/package.json (or the root package.json /
+    # bun.lock): `docker compose down -v && docker compose up --build -d`.
+    command: sh -c "npm run dev -- --host"
     depends_on:
       - backend
 

--- a/docs/superpowers/plans/2026-08-18-deps-bun-sqlite.md
+++ b/docs/superpowers/plans/2026-08-18-deps-bun-sqlite.md
@@ -3684,6 +3684,8 @@ docker compose down -v
 docker compose up
 ```
 
+**`down -v` détruit des données.** Il supprime tous les volumes nommés du projet : la base SQLite de développement, les savestates, les avatars et le cache Redis. C'est voulu ici — tester le chemin de baseline demande une base vierge — mais prévenir la personne qui exécute avant de lancer, et lui laisser sauvegarder `backend-data` si elle y tient.
+
 Si le backend échoue au démarrage sur une base vide, corriger `docker-compose.yml` en inversant la dépendance, comme `docker-compose.prod.yml` le fait déjà :
 
 ```yaml
@@ -3740,6 +3742,8 @@ docker compose -f docker-compose.prod.yml build
 docker compose down -v && docker compose up -d
 npx playwright test --config e2e/playwright.config.ts
 ```
+
+Même avertissement qu'au Step 4 : ce `down -v` efface la base de développement, les savestates, les avatars et Redis. Il est là pour partir d'un état propre avant la suite Playwright ; le dire avant de le lancer.
 
 Attendu : tout vert, et `grep -rn "prisma" backend/ --include='*.ts' --include='*.json' --include='Dockerfile*'` ne renvoie plus rien.
 

--- a/docs/superpowers/plans/2026-08-18-deps-bun-sqlite.md
+++ b/docs/superpowers/plans/2026-08-18-deps-bun-sqlite.md
@@ -1,0 +1,3786 @@
+# Alléger les dépendances, passer à Bun, sortir de Prisma — plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retirer les dépendances mortes, faire installer Bun à la place de npm, et remplacer Prisma par `better-sqlite3` derrière des modules de dépôt testés.
+
+**Architecture:** Trois phases séquentielles, du risque nul au risque réel. La phase 3 introduit `backend/src/db/` comme unique frontière entre le serveur et SQLite : cinq modules de dépôt exposant des fonctions nommées, un runner de migrations qui refuse de démarrer sur un schéma divergent, et aucun `import` de driver ailleurs dans le code.
+
+**Tech Stack:** Node 20, TypeScript, better-sqlite3, Bun (installateur uniquement), Docker Compose, `node --test` avec tsx.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-deps-bun-sqlite-design.md`
+
+## Global Constraints
+
+- **Node reste le runtime.** Bun n'installe que. Aucun `bun run` hors des Dockerfiles, aucun `bun test`.
+- **Les tests tournent avec `node --import tsx --test`**, comme les 12 suites existantes de `core/test`.
+- **Aucun `import` de `better-sqlite3` en dehors de `backend/src/db/`.** C'est ce qui rendra la bascule vers `bun:sqlite` possible plus tard.
+- **Les dates sont des entiers en base, des `Date` en mémoire.** Conversion `new Date(n)` en lecture, `.getTime()` en écriture, exclusivement dans les convertisseurs de ligne.
+- **Prisma génère trois choses que SQL brut ne génère pas** : les `id` (`@default(uuid())`), les `createdAt` (`@default(now())`) et les `updatedAt` (`@updatedAt`). Chaque `INSERT` fournit les trois ; chaque `UPDATE` sur une table qui a `updatedAt` le fournit aussi.
+- **`PRAGMA foreign_keys = ON` à chaque ouverture de connexion.** `DELETE FROM Game` compte sur la cascade pour emporter les `Save`.
+- **Ne rien commiter sans l'accord explicite du propriétaire du dépôt** (`CLAUDE.md`). Les étapes « Commit » du plan préparent le message et attendent le feu vert.
+- Format des messages de commit : impératif, en anglais, une ligne — le style de l'historique (`Restore rooms at boot and save them on the way out`).
+
+## Structure des fichiers
+
+**Phase 1 — modifiés**
+
+- `frontend/package.json` — cinq dépendances retirées
+- `frontend/vite.config.ts` — alias et `optimizeDeps` correspondants retirés
+
+**Phase 2 — modifiés**
+
+- `backend/Dockerfile`, `backend/dev.Dockerfile`, `frontend/Dockerfile` — Bun installe
+- `docker-compose.yml` — les deux lignes `command:`
+- `package.json` — workspaces
+
+**Phase 3 — créés**
+
+| Fichier | Responsabilité |
+|---|---|
+| `backend/src/db/sqlite.ts` | ouvrir la connexion, appliquer les pragmas, résoudre `DATABASE_URL` |
+| `backend/src/db/types.ts` | les cinq interfaces de ligne, écrites à la main |
+| `backend/src/db/migrate.ts` | le runner : baseline, comparaison de schéma, refus |
+| `backend/src/db/migrate-cli.ts` | point d'entrée exécutable du service `db-migration` |
+| `backend/migrations/0001_baseline.sql` | le schéma d'aujourd'hui |
+| `backend/src/db/users.ts` | 9 fonctions |
+| `backend/src/db/friendships.ts` | 9 fonctions, dont 4 jointures |
+| `backend/src/db/games.ts` | 15 fonctions, dont 2 jointures |
+| `backend/src/db/saves.ts` | 4 fonctions, dont 1 jointure |
+| `backend/src/db/game-metadata.ts` | 5 fonctions |
+| `backend/test/*.test.ts` | les suites, hors `tsconfig.json` qui n'inclut que `src/**/*` |
+
+**Phase 3 — supprimés**
+
+`backend/src/db/prisma.ts`, `backend/prisma/schema.prisma`, `backend/prisma/migrations/`, les dépendances `prisma` et `@prisma/client`, les scripts `db:generate` et `db:migrate`.
+
+**Note de déviation par rapport à la spec.** La spec plaçait les migrations dans `backend/src/db/migrations/`. Elles vont dans `backend/migrations/` : `tsc` ne copie pas les fichiers `.sql` vers `dist/`, donc des migrations sous `src/` seraient absentes de l'image de production. `backend/migrations/` est copié explicitement par le Dockerfile, comme `backend/prisma` l'était.
+
+---
+
+## Phase 1 — Reliquat de #11
+
+### Task 1: Retirer les dépendances frontend sans consommateur
+
+**Files:**
+- Modify: `frontend/package.json`
+- Modify: `frontend/vite.config.ts:8-25`
+
+**Interfaces:**
+- Consumes: rien
+- Produces: rien — aucune autre tâche n'en dépend
+
+- [ ] **Step 1: Relever la mesure de départ**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+du -sh node_modules
+grep -c '"node_modules/' package-lock.json
+```
+
+Noter les deux valeurs. Attendu au moment de l'écriture : `257M` et `461`.
+
+- [ ] **Step 2: Vérifier une dernière fois qu'aucun des cinq n'est importé**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+for p in "@sveltejs/adapter-auto" "@sveltejs/adapter-node" stream-browserify events util; do
+  echo "-- $p"
+  grep -rn "from '$p'\|require('$p')\|from \"$p\"" frontend/src core backend/src 2>/dev/null
+done
+grep -n "adapter-auto\|adapter-node" frontend/svelte.config.js
+```
+
+Attendu : aucune ligne de résultat pour les `grep -rn`, et rien non plus dans `svelte.config.js`, qui importe `@sveltejs/adapter-static`. Si l'un des cinq apparaît, **arrêter** et signaler : la prémisse de la tâche est fausse.
+
+`events` et `util` méritent une attention particulière : ils sont aliasés vers eux-mêmes dans `vite.config.ts` (`events: 'events'`), donc un import de `'events'` résoudrait vers le package npm. Le `grep` ci-dessus le détecterait.
+
+- [ ] **Step 3: Retirer les cinq dépendances**
+
+Dans `frontend/package.json`, supprimer de `devDependencies` :
+
+```json
+    "@sveltejs/adapter-auto": "^3.1.1",
+    "@sveltejs/adapter-node": "^5.0.1",
+```
+
+et de `dependencies` :
+
+```json
+    "events": "^3.3.0",
+    "stream-browserify": "^3.0.0",
+    "util": "^0.12.5",
+```
+
+- [ ] **Step 4: Retirer les alias correspondants**
+
+Dans `frontend/vite.config.ts`, `resolve.alias` passe de :
+
+```ts
+    alias: {
+      buffer: 'buffer/',
+      stream: 'stream-browserify',
+      events: 'events',
+      util: 'util/',
+      path: 'path-browserify',
+    },
+```
+
+à :
+
+```ts
+    alias: {
+      buffer: 'buffer/',
+      path: 'path-browserify',
+    },
+```
+
+et `optimizeDeps.include` de :
+
+```ts
+    include: ['simple-peer', 'buffer', 'process', 'events', 'util', 'stream-browserify', 'ini', 'path-browserify'],
+```
+
+à :
+
+```ts
+    include: ['simple-peer', 'buffer', 'process', 'ini', 'path-browserify'],
+```
+
+`buffer`, `process`, `ini` et `path-browserify` restent : `polyfills.ts` importe les deux premiers, `vendors.ts:1` importe `ini`, et `simple-peer` a besoin de `buffer` et `process`.
+
+- [ ] **Step 5: Réinstaller et construire le frontend**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+npm install
+npm run build --workspace=psnes-frontend
+```
+
+Attendu : le build passe. S'il échoue sur un module introuvable, c'est qu'un des cinq était utilisé par une dépendance transitive de `simple-peer` sans être importé directement — remettre celui-là seul et noter pourquoi.
+
+- [ ] **Step 6: Vérifier que simple-peer fonctionne toujours dans le navigateur**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+npx playwright test --config e2e/playwright.config.ts
+```
+
+Attendu : la suite passe comme avant le changement. C'est le seul test qui exerce réellement le chemin WebRTC que les polyfills servent.
+
+- [ ] **Step 7: Relever la mesure d'arrivée**
+
+```bash
+du -sh node_modules
+grep -c '"node_modules/' package-lock.json
+```
+
+Consigner l'écart dans le message de commit.
+
+- [ ] **Step 8: Commit (demander l'accord d'abord)**
+
+```bash
+git add frontend/package.json frontend/vite.config.ts package-lock.json
+git commit -m "Drop five frontend packages nothing imported"
+```
+
+---
+
+## Phase 2 — #10 Partie 1, Bun comme package manager
+
+### Task 2: Faire installer Bun dans les trois Dockerfiles
+
+**Files:**
+- Modify: `backend/Dockerfile:5-8,20-26,41`
+- Modify: `backend/dev.Dockerfile:1-16`
+- Modify: `frontend/Dockerfile:1-22`
+
+**Interfaces:**
+- Consumes: rien
+- Produces: des images où `bun` est sur le `PATH` et `bun.lockb` fait foi ; la Task 3 s'appuie dessus pour les `command:` de compose
+
+- [ ] **Step 1: Générer le lockfile Bun localement**
+
+Bun doit être présent sur la machine hôte pour produire `bun.lockb` :
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+export PATH="$HOME/.bun/bin:$PATH"
+bun --version
+```
+
+Puis, à la racine du dépôt :
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+bun install
+ls -la bun.lockb
+```
+
+Attendu : `bun.lockb` existe. `package-lock.json` reste au dépôt — la spec le garde jusqu'à ce que la phase soit jugée stable.
+
+- [ ] **Step 2: Vérifier que le hoisting des workspaces n'a rien cassé**
+
+C'est le risque propre au changement d'installateur : Bun et npm ne placent pas les paquets aux mêmes endroits.
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+ls node_modules/.bin/tsx node_modules/.bin/vite 2>&1
+npm run test:all
+```
+
+Attendu : les binaires existent et les 12 suites passent. Si `tsx` est introuvable, le hoisting diffère — l'ajouter explicitement aux dépendances du workspace qui l'appelle plutôt que de contourner.
+
+- [ ] **Step 3: Ajouter Bun à `backend/Dockerfile`**
+
+L'image de base reste `node:20` : Node exécute toujours. Le binaire Bun est copié depuis l'image officielle, une couche déterministe qui ne se réinvalide pas à chaque build.
+
+Remplacer l'en-tête de l'étape `prod-deps` :
+
+```dockerfile
+FROM node:20 AS prod-deps
+
+WORKDIR /app
+ENV NODE_ENV=build
+
+COPY backend/package*.json ./
+COPY package-lock.json ./
+
+RUN npm ci --omit=dev --prefer-offline
+```
+
+par :
+
+```dockerfile
+FROM node:20 AS prod-deps
+
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+
+WORKDIR /app
+ENV NODE_ENV=build
+
+COPY backend/package.json ./
+COPY bun.lockb ./
+
+RUN bun install --production --frozen-lockfile
+```
+
+- [ ] **Step 4: Basculer l'étape `builder` du même Dockerfile**
+
+Remplacer :
+
+```dockerfile
+RUN npm ci --prefer-offline
+```
+
+par :
+
+```dockerfile
+RUN bun install --frozen-lockfile
+```
+
+et :
+
+```dockerfile
+RUN npm run build
+```
+
+par :
+
+```dockerfile
+RUN bun run build
+```
+
+`bun run build` invoque le script `build` du `package.json`, qui appelle `tsc` — c'est toujours TypeScript qui compile, et toujours Node qui exécutera le résultat.
+
+- [ ] **Step 5: Basculer `backend/dev.Dockerfile`**
+
+Ajouter la ligne de copie sous le `FROM`, puis remplacer `RUN npm install` par `RUN bun install` :
+
+```dockerfile
+FROM node:20
+
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    python3 make g++ pkg-config \
+    libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY backend/package.json ./
+COPY bun.lockb ./
+RUN bun install
+
+COPY backend/prisma ./prisma
+RUN npx prisma generate
+
+CMD ["npm", "run", "dev"]
+```
+
+`npx prisma generate` reste ici : la phase 3 le supprimera. Le `CMD` reste sur `npm run dev` — il est de toute façon écrasé par le `command:` de compose, que la Task 3 traite.
+
+- [ ] **Step 6: Basculer `frontend/Dockerfile`**
+
+Ajouter la copie du binaire sous le `FROM builder`, puis remplacer :
+
+```dockerfile
+COPY package*.json ./
+RUN npm install && \
+    npm cache clean --force
+```
+
+par :
+
+```dockerfile
+COPY package.json ./
+RUN bun install
+```
+
+(`bun cache clean` n'a pas d'équivalent utile ici : le cache de Bun vit hors du répertoire de travail et ne gonfle pas la couche.)
+
+Puis remplacer `RUN npm run build` par `RUN bun run build`, et `RUN npx svelte-kit sync` par `RUN bunx svelte-kit sync`.
+
+- [ ] **Step 7: Construire les trois images**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+docker compose build
+docker compose -f docker-compose.prod.yml build
+```
+
+Attendu : les deux builds réussissent. L'échec le plus probable est `bun.lockb` absent du contexte de build — le `.dockerignore`, s'il existe, doit le laisser passer.
+
+- [ ] **Step 8: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/Dockerfile backend/dev.Dockerfile frontend/Dockerfile bun.lockb
+git commit -m "Let Bun install what npm used to"
+```
+
+### Task 3: Remplacer les `npm install` au démarrage des conteneurs
+
+**Files:**
+- Modify: `docker-compose.yml:47,64`
+- Modify: `package.json:4-7`
+
+**Interfaces:**
+- Consumes: les images de la Task 2, où `bun` est sur le `PATH`
+- Produces: un `docker compose up` qui ne réinstalle plus 461 paquets à chaque démarrage
+
+- [ ] **Step 1: Basculer le `command:` du backend**
+
+`docker-compose.yml`, service `backend`, remplacer :
+
+```yaml
+    command: sh -c "npm install && npx prisma generate && npm run dev"
+```
+
+par :
+
+```yaml
+    command: sh -c "bun install && npx prisma generate && npm run dev"
+```
+
+`npm run dev` est conservé volontairement : il lance `tsx watch src/index.ts`, exécuté par Node. Seule l'installation change.
+
+- [ ] **Step 2: Basculer le `command:` du frontend**
+
+Même fichier, service `frontend`, remplacer :
+
+```yaml
+    command: sh -c "npm install && npm run dev -- --host"
+```
+
+par :
+
+```yaml
+    command: sh -c "bun install && npm run dev -- --host"
+```
+
+Ce service utilise l'image `node:20-alpine` brute, pas un Dockerfile — Bun n'y est donc pas, et `bun install` échouerait. Il lui faut une image qui porte les deux : Bun pour installer, Node pour exécuter Vite. Basculer `oven/bun:1` ne conviendrait pas, cette image n'embarque pas Node.
+
+Donner au frontend un Dockerfile de développement symétrique de `backend/dev.Dockerfile`. Créer `frontend/dev.Dockerfile` :
+
+```dockerfile
+FROM node:20
+
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+
+WORKDIR /app
+
+CMD ["npm", "run", "dev", "--", "--host"]
+```
+
+et dans `docker-compose.yml`, service `frontend`, remplacer `image: node:20-alpine` par :
+
+```yaml
+    build:
+      context: .
+      dockerfile: frontend/dev.Dockerfile
+```
+
+en gardant `command: sh -c "bun install && npm run dev -- --host"`.
+
+- [ ] **Step 3: Convertir les workspaces**
+
+Bun lit le champ `workspaces` de `package.json` avec la même syntaxe que npm — aucun changement n'est nécessaire à ce champ. Vérifier seulement qu'il est bien pris en compte :
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+bun install
+ls -d node_modules/psnes-backend node_modules/psnes-frontend
+```
+
+Attendu : les deux liens symboliques de workspace existent. Si Bun ne les crée pas, c'est la seule divergence de workspaces qui compte ici — la signaler plutôt que de la contourner.
+
+- [ ] **Step 4: Mesurer le gain, qui est l'objet de l'issue**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+docker compose down -v
+time docker compose up -d
+docker compose logs backend | head -30
+```
+
+Attendu : la pile démarre, et le temps d'installation au démarrage a nettement baissé. Consigner la valeur : c'est la preuve que #10 demandait.
+
+- [ ] **Step 5: Vérifier que rien n'a régressé**
+
+```bash
+npm run test:all
+npx playwright test --config e2e/playwright.config.ts
+```
+
+Attendu : 12 suites `core/test` passantes, suite Playwright passante. Les scripts de test n'ont pas changé — ils tournent toujours sous `node --import tsx --test`.
+
+- [ ] **Step 6: Commit (demander l'accord d'abord)**
+
+```bash
+git add docker-compose.yml frontend/dev.Dockerfile
+git commit -m "Stop reinstalling 461 packages on every container start"
+```
+
+---
+
+## Phase 3 — #13, Prisma → better-sqlite3
+
+### Task 4: Ouvrir une connexion SQLite, avec ses pragmas
+
+**Files:**
+- Create: `backend/src/db/sqlite.ts`
+- Create: `backend/test/sqlite.test.ts`
+- Modify: `backend/package.json` (dépendances et script de test)
+- Modify: `package.json` (script `test:backend`)
+
+**Interfaces:**
+- Consumes: rien
+- Produces:
+  - `openDatabase(file: string): Database` — ouvre, applique les pragmas
+  - `databaseFileFromUrl(url: string): string` — `file:/app/data/dev.db` → `/app/data/dev.db`
+  - `getDb(): Database` — la connexion du processus, ouverte à la première demande depuis `DATABASE_URL`
+  - `closeDb(): void` — pour les tests
+  - `type Database` — ré-export du type de better-sqlite3, pour que rien d'autre n'ait à l'importer
+
+- [ ] **Step 1: Installer better-sqlite3 et ses types**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+bun add --cwd backend better-sqlite3
+bun add --cwd backend --dev @types/better-sqlite3
+```
+
+Si `bun add --cwd` n'est pas disponible dans la version installée, éditer `backend/package.json` à la main et relancer `bun install` à la racine.
+
+- [ ] **Step 2: Ajouter le script de test backend**
+
+Dans `package.json` à la racine, ajouter à `scripts` :
+
+```json
+    "test:backend": "node --import tsx --test backend/test/*.test.ts",
+```
+
+et étendre `test:all` :
+
+```json
+    "test:all": "npm run test:netplay && npm run test:core && npm run test:ui && npm run test:backend"
+```
+
+Les tests vivent dans `backend/test/`, hors du `include: ["src/**/*"]` de `backend/tsconfig.json` — ils ne partiront donc pas dans `dist/`.
+
+- [ ] **Step 3: Écrire le test qui échoue**
+
+Créer `backend/test/sqlite.test.ts` :
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openDatabase, databaseFileFromUrl } from '../src/db/sqlite.js';
+
+function tempFile(name: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'psnes-db-'));
+  return join(dir, name);
+}
+
+test('databaseFileFromUrl strips the file: prefix Prisma used', () => {
+  assert.equal(databaseFileFromUrl('file:/app/data/dev.db'), '/app/data/dev.db');
+  assert.equal(databaseFileFromUrl('file:./prisma/data/dev.db'), './prisma/data/dev.db');
+});
+
+test('databaseFileFromUrl accepts a bare path', () => {
+  assert.equal(databaseFileFromUrl('/app/data/dev.db'), '/app/data/dev.db');
+});
+
+test('openDatabase enforces foreign keys, so cascades actually cascade', () => {
+  const file = tempFile('fk.db');
+  const db = openDatabase(file);
+
+  db.exec(`
+    CREATE TABLE parent (id TEXT PRIMARY KEY);
+    CREATE TABLE child (
+      id TEXT PRIMARY KEY,
+      parentId TEXT NOT NULL REFERENCES parent(id) ON DELETE CASCADE
+    );
+  `);
+  db.prepare(`INSERT INTO parent (id) VALUES ('p')`).run();
+  db.prepare(`INSERT INTO child (id, parentId) VALUES ('c', 'p')`).run();
+
+  db.prepare(`DELETE FROM parent WHERE id = 'p'`).run();
+
+  const remaining = db.prepare(`SELECT COUNT(*) AS n FROM child`).get() as { n: number };
+  assert.equal(remaining.n, 0, 'the child row should have been cascaded away');
+
+  db.close();
+  rmSync(file, { force: true });
+});
+
+test('openDatabase uses WAL, so a reader never blocks the writer', () => {
+  const file = tempFile('wal.db');
+  const db = openDatabase(file);
+  const mode = db.pragma('journal_mode', { simple: true });
+  assert.equal(mode, 'wal');
+  db.close();
+  rmSync(file, { force: true });
+});
+```
+
+Le test des clés étrangères n'est pas décoratif : SQLite les désactive par défaut, et `games.ts:154` supprime un jeu en comptant sur la cascade pour emporter ses sauvegardes. Sans ce pragma, les `Save` deviendraient orphelines en silence.
+
+- [ ] **Step 4: Lancer le test pour le voir échouer**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+node --import tsx --test backend/test/sqlite.test.ts
+```
+
+Attendu : ÉCHEC — `Cannot find module '../src/db/sqlite.js'`.
+
+- [ ] **Step 5: Écrire l'implémentation minimale**
+
+Créer `backend/src/db/sqlite.ts` :
+
+```ts
+import BetterSqlite3 from 'better-sqlite3';
+
+export type Database = BetterSqlite3.Database;
+
+/**
+ * Prisma addressed the database through a `file:` URL. The environment still
+ * carries that form in DATABASE_URL, in compose files and in deployments we do
+ * not control, so we keep reading it rather than asking every deployment to
+ * change on the same day as the driver.
+ */
+export function databaseFileFromUrl(url: string): string {
+  return url.startsWith('file:') ? url.slice('file:'.length) : url;
+}
+
+export function openDatabase(file: string): Database {
+  const db = new BetterSqlite3(file);
+  // SQLite ships with foreign keys off. Deleting a Game relies on the cascade
+  // to take its Saves with it, so this is load-bearing, not hygiene.
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+  return db;
+}
+
+let instance: Database | null = null;
+
+export function getDb(): Database {
+  if (!instance) {
+    const url = process.env.DATABASE_URL;
+    if (!url) {
+      throw new Error('DATABASE_URL is not set');
+    }
+    instance = openDatabase(databaseFileFromUrl(url));
+  }
+  return instance;
+}
+
+export function closeDb(): void {
+  instance?.close();
+  instance = null;
+}
+```
+
+- [ ] **Step 6: Lancer le test pour le voir passer**
+
+```bash
+node --import tsx --test backend/test/sqlite.test.ts
+```
+
+Attendu : 4 tests passants.
+
+- [ ] **Step 7: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/db/sqlite.ts backend/test/sqlite.test.ts backend/package.json package.json bun.lockb
+git commit -m "Open SQLite directly, with the pragmas cascades need"
+```
+
+### Task 5: Écrire les types de ligne à la main
+
+**Files:**
+- Create: `backend/src/db/types.ts`
+- Create: `backend/migrations/0001_baseline.sql`
+
+**Interfaces:**
+- Consumes: rien
+- Produces: `User`, `Game`, `Save`, `Friendship`, `GameMetadata` — les cinq interfaces que tous les modules de dépôt renvoient
+
+- [ ] **Step 1: Produire la baseline depuis la base de référence**
+
+La baseline doit décrire exactement ce que les huit migrations Prisma produisent, sans être écrite à la main. La fabriquer :
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes/backend
+export DATABASE_URL="file:/tmp/psnes-baseline.db"
+rm -f /tmp/psnes-baseline.db
+npx prisma migrate deploy
+node --input-type=module -e "
+import BetterSqlite3 from 'better-sqlite3';
+const db = new BetterSqlite3('/tmp/psnes-baseline.db');
+const rows = db.prepare(\`
+  SELECT sql FROM sqlite_master
+  WHERE sql IS NOT NULL
+    AND name NOT LIKE 'sqlite_%'
+    AND name != '_prisma_migrations'
+  ORDER BY CASE type WHEN 'table' THEN 0 ELSE 1 END, name
+\`).all();
+console.log(rows.map(r => r.sql + ';').join('\n\n'));
+" > migrations/0001_baseline.sql
+head -20 migrations/0001_baseline.sql
+```
+
+Créer le répertoire d'abord si besoin (`mkdir -p backend/migrations`). Attendu : un fichier contenant les `CREATE TABLE` de `User`, `Friendship`, `GameMetadata`, `Game`, `Save` puis les `CREATE INDEX` / `CREATE UNIQUE INDEX`.
+
+L'ordre compte : les tables avant les index, et `User` avant `Friendship` et `Game` qui la référencent. Le `ORDER BY` ci-dessus met les tables en premier ; vérifier à l'œil que `User` précède ses dépendants et réordonner sinon.
+
+- [ ] **Step 2: Écrire les interfaces**
+
+Créer `backend/src/db/types.ts` :
+
+```ts
+/**
+ * The row shapes, written by hand now that no generator writes them.
+ *
+ * Dates are `Date` here and integers on disk: SQLite has no date type, and
+ * Prisma stored every DATETIME column as milliseconds since the epoch. The
+ * conversion lives in the row converters of each repository module, nowhere
+ * else.
+ */
+
+export interface User {
+  id: string;
+  googleId: string;
+  email: string;
+  displayName: string;
+  avatar: string | null;
+  controlsConfig: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** What the friend search and the online-friends list are allowed to expose. */
+export interface UserSummary {
+  id: string;
+  email: string;
+  displayName: string;
+  avatar: string | null;
+}
+
+export interface Friendship {
+  id: string;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+  initiatorId: string;
+  receiverId: string;
+}
+
+export interface Game {
+  id: string;
+  title: string;
+  filename: string;
+  coverUrl: string | null;
+  uploadedAt: Date;
+  genre: string | null;
+  publisher: string | null;
+  developer: string | null;
+  releaseDate: string | null;
+  players: string | null;
+  region: string | null;
+  description: string | null;
+  crc32: string | null;
+  sram: Buffer | null;
+  sramUpdatedAt: Date | null;
+  userId: string;
+}
+
+export interface Save {
+  id: string;
+  name: string;
+  slotNumber: number;
+  data: Buffer;
+  screenshot: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  gameId: string;
+}
+
+/** The subset of a Save that the library listing sends: never the blob. */
+export interface SaveSummary {
+  id: string;
+  name: string;
+  slotNumber: number;
+  screenshot: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface GameMetadata {
+  id: string;
+  title: string;
+  altTitle: string | null;
+  genre: string | null;
+  publisher: string | null;
+  developer: string | null;
+  releaseDate: string | null;
+  players: string | null;
+  region: string | null;
+  description: string | null;
+  coverUrl: string | null;
+  crc32: string | null;
+  md5: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+- [ ] **Step 3: Vérifier que les interfaces couvrent le schéma, colonne par colonne**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+node --input-type=module -e "
+import BetterSqlite3 from 'better-sqlite3';
+const db = new BetterSqlite3('/tmp/psnes-baseline.db');
+for (const t of ['User','Friendship','Game','Save','GameMetadata']) {
+  const cols = db.prepare(\`PRAGMA table_info('\${t}')\`).all();
+  console.log(t + ': ' + cols.map(c => c.name + (c.notnull ? '' : '?')).join(', '));
+}
+"
+```
+
+Attendu : chaque colonne listée a son champ dans `types.ts`, et les colonnes marquées `?` (nullable) sont typées `| null`. Corriger toute divergence maintenant — une interface fausse ici se propage aux cinq modules.
+
+- [ ] **Step 4: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/db/types.ts backend/migrations/0001_baseline.sql
+git commit -m "Write down the row shapes a generator used to write"
+```
+
+### Task 6: Le runner de migrations, et son refus de démarrer
+
+**Files:**
+- Create: `backend/src/db/migrate.ts`
+- Create: `backend/test/migrate.test.ts`
+
+**Interfaces:**
+- Consumes: `openDatabase` de `backend/src/db/sqlite.ts`
+- Produces:
+  - `migrate(db: Database, migrationsDir: string): MigrationResult`
+  - `interface MigrationResult { applied: string[]; baselined: string[] }`
+  - `class SchemaDriftError extends Error` — porte `.differences: string[]`
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `backend/test/migrate.test.ts` :
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openDatabase } from '../src/db/sqlite.js';
+import { migrate, SchemaDriftError } from '../src/db/migrate.js';
+
+const BASELINE = `CREATE TABLE "Widget" ("id" TEXT NOT NULL PRIMARY KEY, "label" TEXT NOT NULL);`;
+const SECOND = `ALTER TABLE "Widget" ADD COLUMN "colour" TEXT;`;
+
+function fixture(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'psnes-mig-'));
+  mkdirSync(join(dir, 'migrations'), { recursive: true });
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(dir, 'migrations', name), body);
+  }
+  return join(dir, 'migrations');
+}
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), 'psnes-mig-db-'));
+  return openDatabase(join(dir, 'test.db'));
+}
+
+test('an empty database gets every migration applied in order', () => {
+  const dir = fixture({ '0001_baseline.sql': BASELINE, '0002_colour.sql': SECOND });
+  const db = freshDb();
+
+  const result = migrate(db, dir);
+
+  assert.deepEqual(result.applied, ['0001_baseline.sql', '0002_colour.sql']);
+  assert.deepEqual(result.baselined, []);
+  const cols = db.prepare(`PRAGMA table_info('Widget')`).all() as { name: string }[];
+  assert.deepEqual(cols.map(c => c.name), ['id', 'label', 'colour']);
+  db.close();
+});
+
+test('running twice applies nothing the second time', () => {
+  const dir = fixture({ '0001_baseline.sql': BASELINE, '0002_colour.sql': SECOND });
+  const db = freshDb();
+
+  migrate(db, dir);
+  const second = migrate(db, dir);
+
+  assert.deepEqual(second.applied, []);
+  db.close();
+});
+
+test('an existing database matching the baseline is recorded, not re-run', () => {
+  const dir = fixture({ '0001_baseline.sql': BASELINE });
+  const db = freshDb();
+  // Stand in for a database Prisma built: the schema is there, our bookkeeping
+  // table is not.
+  db.exec(BASELINE);
+  db.exec(`CREATE TABLE "_prisma_migrations" ("id" TEXT PRIMARY KEY)`);
+
+  const result = migrate(db, dir);
+
+  assert.deepEqual(result.baselined, ['0001_baseline.sql']);
+  assert.deepEqual(result.applied, []);
+});
+
+test('an existing database that has drifted refuses to start', () => {
+  const dir = fixture({ '0001_baseline.sql': BASELINE });
+  const db = freshDb();
+  // One column short of what the baseline produces - exactly the drift #7
+  // warned would otherwise be frozen where nobody looks.
+  db.exec(`CREATE TABLE "Widget" ("id" TEXT NOT NULL PRIMARY KEY)`);
+  db.exec(`CREATE TABLE "_prisma_migrations" ("id" TEXT PRIMARY KEY)`);
+
+  assert.throws(
+    () => migrate(db, dir),
+    (err: unknown) => {
+      assert.ok(err instanceof SchemaDriftError);
+      assert.ok(err.differences.length > 0, 'the error should say what differs');
+      assert.ok(err.differences.join('\n').includes('Widget'));
+      return true;
+    }
+  );
+});
+
+test('after baselining, later migrations still apply', () => {
+  const dir = fixture({ '0001_baseline.sql': BASELINE, '0002_colour.sql': SECOND });
+  const db = freshDb();
+  db.exec(BASELINE);
+
+  const result = migrate(db, dir);
+
+  assert.deepEqual(result.baselined, ['0001_baseline.sql']);
+  assert.deepEqual(result.applied, ['0002_colour.sql']);
+  const cols = db.prepare(`PRAGMA table_info('Widget')`).all() as { name: string }[];
+  assert.ok(cols.some(c => c.name === 'colour'));
+});
+
+test('a failing migration leaves the database untouched', () => {
+  const dir = fixture({
+    '0001_baseline.sql': BASELINE,
+    '0002_broken.sql': `ALTER TABLE "Nope" ADD COLUMN "x" TEXT;`
+  });
+  const db = freshDb();
+
+  assert.throws(() => migrate(db, dir));
+
+  const recorded = db.prepare(`SELECT name FROM schema_migrations`).all() as { name: string }[];
+  assert.deepEqual(recorded.map(r => r.name), ['0001_baseline.sql']);
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour les voir échouer**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+node --import tsx --test backend/test/migrate.test.ts
+```
+
+Attendu : ÉCHEC — `Cannot find module '../src/db/migrate.js'`.
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Créer `backend/src/db/migrate.ts` :
+
+```ts
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Database } from './sqlite.js';
+import BetterSqlite3 from 'better-sqlite3';
+
+export interface MigrationResult {
+  /** Migrations whose SQL was executed. */
+  applied: string[];
+  /** Migrations recorded as already present, because the schema was there. */
+  baselined: string[];
+}
+
+export class SchemaDriftError extends Error {
+  constructor(public readonly differences: string[]) {
+    super(
+      'The database schema does not match what the migrations produce. ' +
+      'Refusing to start rather than record a baseline that is not true.\n\n' +
+      differences.join('\n')
+    );
+    this.name = 'SchemaDriftError';
+  }
+}
+
+function ensureBookkeeping(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      name TEXT PRIMARY KEY,
+      applied_at INTEGER NOT NULL
+    )
+  `);
+}
+
+function listMigrations(dir: string): string[] {
+  return readdirSync(dir).filter(f => f.endsWith('.sql')).sort();
+}
+
+function alreadyRecorded(db: Database): Set<string> {
+  const rows = db.prepare(`SELECT name FROM schema_migrations`).all() as { name: string }[];
+  return new Set(rows.map(r => r.name));
+}
+
+/** The schema as SQLite itself describes it, normalised so whitespace does not matter. */
+function schemaOf(db: Database): Map<string, string> {
+  const rows = db.prepare(`
+    SELECT name, sql FROM sqlite_master
+    WHERE sql IS NOT NULL
+      AND name NOT LIKE 'sqlite_%'
+      AND name NOT IN ('_prisma_migrations', 'schema_migrations')
+  `).all() as { name: string; sql: string }[];
+
+  return new Map(rows.map(r => [r.name, r.sql.replace(/\s+/g, ' ').trim()]));
+}
+
+/** Does this database already carry a schema, or is it blank? */
+function hasExistingSchema(db: Database): boolean {
+  return schemaOf(db).size > 0;
+}
+
+/**
+ * What the baseline alone would produce, built in memory so nothing on disk is
+ * touched by the check.
+ */
+function expectedBaselineSchema(baselineSql: string): Map<string, string> {
+  const probe: Database = new BetterSqlite3(':memory:');
+  try {
+    probe.exec(baselineSql);
+    return schemaOf(probe);
+  } finally {
+    probe.close();
+  }
+}
+
+function diffSchemas(live: Map<string, string>, expected: Map<string, string>): string[] {
+  const differences: string[] = [];
+  for (const [name, sql] of expected) {
+    if (!live.has(name)) {
+      differences.push(`missing from the database: ${name}`);
+    } else if (live.get(name) !== sql) {
+      differences.push(
+        `different definition for ${name}:\n  database:   ${live.get(name)}\n  migrations: ${sql}`
+      );
+    }
+  }
+  for (const name of live.keys()) {
+    if (!expected.has(name)) {
+      differences.push(`present in the database but not in the migrations: ${name}`);
+    }
+  }
+  return differences;
+}
+
+/**
+ * Brings the database up to date.
+ *
+ * On a blank database every migration runs. On a database that already carries
+ * a schema - the one Prisma left behind - the baseline is compared against what
+ * it would produce and recorded only if they match; a mismatch throws rather
+ * than being stamped over. That refusal is the point: #7 was not about `db
+ * push` applying a schema, it was about nobody checking that the live database
+ * matched the files.
+ */
+export function migrate(db: Database, migrationsDir: string): MigrationResult {
+  const files = listMigrations(migrationsDir);
+  if (files.length === 0) {
+    throw new Error(`No migrations found in ${migrationsDir}`);
+  }
+
+  const needsBaseline = !db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'`)
+    .get() && hasExistingSchema(db);
+
+  ensureBookkeeping(db);
+
+  const result: MigrationResult = { applied: [], baselined: [] };
+  const recorded = alreadyRecorded(db);
+  const [baselineFile, ...rest] = files;
+
+  if (needsBaseline) {
+    const baselineSql = readFileSync(join(migrationsDir, baselineFile), 'utf-8');
+    const differences = diffSchemas(schemaOf(db), expectedBaselineSchema(baselineSql));
+    if (differences.length > 0) {
+      throw new SchemaDriftError(differences);
+    }
+    db.prepare(`INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?)`)
+      .run(baselineFile, Date.now());
+    result.baselined.push(baselineFile);
+    recorded.add(baselineFile);
+  }
+
+  for (const file of [baselineFile, ...rest]) {
+    if (recorded.has(file)) continue;
+    const sql = readFileSync(join(migrationsDir, file), 'utf-8');
+    // Each migration is its own transaction: a failure rolls back that
+    // migration and leaves the ones before it recorded.
+    const run = db.transaction(() => {
+      db.exec(sql);
+      db.prepare(`INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?)`)
+        .run(file, Date.now());
+    });
+    run();
+    result.applied.push(file);
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Lancer les tests pour les voir passer**
+
+```bash
+node --import tsx --test backend/test/migrate.test.ts
+```
+
+Attendu : 6 tests passants. Si « a failing migration leaves the database untouched » échoue, c'est que `db.exec` d'un script multi-instructions ne se laisse pas envelopper dans la transaction de better-sqlite3 — le cas échéant, découper le script sur les `;` et exécuter chaque instruction par `db.prepare().run()` dans la transaction.
+
+- [ ] **Step 5: Vérifier le runner contre la vraie baseline**
+
+Le test précédent utilise une table `Widget` inventée. Celui-ci confronte le runner au schéma réel :
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes/backend
+rm -f /tmp/psnes-real.db
+export DATABASE_URL="file:/tmp/psnes-real.db"
+npx prisma migrate deploy
+node --import tsx -e "
+import { openDatabase } from './src/db/sqlite.js';
+import { migrate } from './src/db/migrate.js';
+const db = openDatabase('/tmp/psnes-real.db');
+console.log(migrate(db, './migrations'));
+"
+```
+
+Attendu : `{ applied: [], baselined: [ '0001_baseline.sql' ] }`. Un `SchemaDriftError` signifierait que la baseline générée à la Task 5 ne reproduit pas ce que les migrations Prisma produisent — corriger la baseline, pas le runner.
+
+- [ ] **Step 6: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/db/migrate.ts backend/test/migrate.test.ts
+git commit -m "Refuse to start when the schema is not what the migrations say"
+```
+
+### Task 7: Le point d'entrée du service de migration
+
+**Files:**
+- Create: `backend/src/db/migrate-cli.ts`
+- Modify: `backend/Dockerfile` (copier `migrations/`)
+- Modify: `docker-compose.yml:19`
+- Modify: `docker-compose.prod.yml:19`
+
+**Interfaces:**
+- Consumes: `migrate`, `SchemaDriftError`, `getDb`, `databaseFileFromUrl`
+- Produces: `dist/db/migrate-cli.js`, exécutable par `node`, code de sortie 1 en cas de dérive
+
+- [ ] **Step 1: Écrire le CLI**
+
+Créer `backend/src/db/migrate-cli.ts` :
+
+```ts
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { getDb } from './sqlite.js';
+import { migrate, SchemaDriftError } from './migrate.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// dist/db/migrate-cli.js -> /app/migrations
+const migrationsDir = join(here, '../../migrations');
+
+try {
+  const result = migrate(getDb(), migrationsDir);
+  for (const name of result.baselined) {
+    console.log(`baselined ${name} (schema already present and matching)`);
+  }
+  for (const name of result.applied) {
+    console.log(`applied ${name}`);
+  }
+  if (result.applied.length === 0 && result.baselined.length === 0) {
+    console.log('database is up to date');
+  }
+  process.exit(0);
+} catch (error) {
+  if (error instanceof SchemaDriftError) {
+    console.error(error.message);
+    process.exit(1);
+  }
+  throw error;
+}
+```
+
+- [ ] **Step 2: Copier les migrations dans l'image**
+
+Dans `backend/Dockerfile`, étape `production`, remplacer :
+
+```dockerfile
+# Copy Prisma schema and runtime dependencies from builder stage
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+```
+
+par :
+
+```dockerfile
+COPY backend/migrations ./migrations
+```
+
+- [ ] **Step 3: Vérifier que le binaire natif de better-sqlite3 survit au multi-étage**
+
+C'est le point de rupture le plus probable du build, identifié dans la spec. L'étape `production` copie `node_modules` depuis `prod-deps`, une image `node:20` ; l'étape d'exécution est `node:20-trixie-slim`. Le `.node` compilé doit être compatible.
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+docker compose -f docker-compose.prod.yml build backend
+docker compose -f docker-compose.prod.yml run --rm --entrypoint sh backend -c \
+  "node -e \"const D=require('better-sqlite3'); const d=new D(':memory:'); d.exec('CREATE TABLE t(x)'); console.log('better-sqlite3 loads');\""
+```
+
+Attendu : `better-sqlite3 loads`. En cas d'échec sur une version de GLIBC ou un `.node` introuvable, ajouter une reconstruction explicite dans l'étape `prod-deps` (`RUN npm rebuild better-sqlite3`) — la chaîne `python3 make g++` y est déjà installée pour l'étape `builder`, il faut la remonter dans `prod-deps`.
+
+- [ ] **Step 4: Basculer les deux services `db-migration`**
+
+Dans `docker-compose.yml` et `docker-compose.prod.yml`, remplacer :
+
+```yaml
+    command: npx prisma migrate deploy
+```
+
+par :
+
+```yaml
+    command: node dist/db/migrate-cli.js
+```
+
+- [ ] **Step 5: Vérifier le comportement de bout en bout, y compris le refus**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+docker compose -f docker-compose.prod.yml up db-migration
+```
+
+Attendu sur un volume vierge : `applied 0001_baseline.sql`, sortie 0. Sur un volume qui porte déjà le schéma : `baselined 0001_baseline.sql`.
+
+Puis provoquer une dérive délibérément et vérifier le refus :
+
+```bash
+docker compose -f docker-compose.prod.yml run --rm --entrypoint sh db-migration -c \
+  "node -e \"const D=require('better-sqlite3'); const d=new D('/app/data/prod.db'); d.exec('ALTER TABLE Game ADD COLUMN drift TEXT');\" && node dist/db/migrate-cli.js; echo exit=\$?"
+```
+
+Attendu : le message de dérive nomme `Game`, et `exit=1`. Retirer ensuite la colonne (`ALTER TABLE Game DROP COLUMN drift`) ou recréer le volume.
+
+Ce test est le seul qui prouve que la garantie de la spec tient dans les conditions réelles, avec le vrai schéma et le vrai chemin de fichier. Ne pas le sauter.
+
+- [ ] **Step 6: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/db/migrate-cli.ts backend/Dockerfile docker-compose.yml docker-compose.prod.yml
+git commit -m "Hand the migration service a runner that checks before it stamps"
+```
+
+### Task 8: Le dépôt des utilisateurs
+
+**Files:**
+- Create: `backend/src/db/users.ts`
+- Create: `backend/test/users.test.ts`
+- Create: `backend/test/helpers.ts`
+
+**Interfaces:**
+- Consumes: `getDb`/`openDatabase`, `migrate`, les types de `types.ts`
+- Produces:
+  - `findUserById(id: string): User | null`
+  - `findUserByGoogleId(googleId: string): User | null`
+  - `findUserByEmail(email: string): User | null`
+  - `createUser(input: { googleId: string; email: string; displayName: string; avatar: string | null }): User`
+  - `updateUserProfile(id: string, input: { displayName: string; avatar: string | null }): User`
+  - `upsertDevUser(input: { id: string; googleId: string; email: string; displayName: string; avatar: string }): User`
+  - `findControlsConfig(userId: string): string | null`
+  - `updateControlsConfig(userId: string, json: string): void`
+  - `searchUsers(excludeUserId: string, query: string, limit: number): UserSummary[]`
+
+- [ ] **Step 1: Écrire le harnais de test partagé**
+
+Créer `backend/test/helpers.ts` :
+
+```ts
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { openDatabase, type Database } from '../src/db/sqlite.js';
+import { migrate } from '../src/db/migrate.js';
+
+/**
+ * A real database on a real file, migrated from the real baseline. Nothing is
+ * mocked: these tests are the only thing standing between 50 rewritten queries
+ * and production.
+ */
+export function migratedDb(): Database {
+  const dir = mkdtempSync(join(tmpdir(), 'psnes-repo-'));
+  const db = openDatabase(join(dir, 'test.db'));
+  migrate(db, resolve(import.meta.dirname, '../migrations'));
+  return db;
+}
+
+export function insertUser(db: Database, over: Partial<{ id: string; googleId: string; email: string; displayName: string; avatar: string | null }> = {}) {
+  const now = Date.now();
+  const row = {
+    id: over.id ?? `user-${Math.floor(now * Math.random())}`,
+    googleId: over.googleId ?? `g-${Math.floor(now * Math.random())}`,
+    email: over.email ?? `u${Math.floor(now * Math.random())}@example.test`,
+    displayName: over.displayName ?? 'Test User',
+    avatar: over.avatar ?? null
+  };
+  db.prepare(`
+    INSERT INTO "User" (id, googleId, email, displayName, avatar, controlsConfig, createdAt, updatedAt)
+    VALUES (@id, @googleId, @email, @displayName, @avatar, NULL, @now, @now)
+  `).run({ ...row, now });
+  return row;
+}
+```
+
+`import.meta.dirname` demande Node 20.11+. La machine tourne sous v20.19.6 ; sous une version plus ancienne, utiliser `dirname(fileURLToPath(import.meta.url))`.
+
+- [ ] **Step 2: Écrire les tests qui échouent**
+
+Créer `backend/test/users.test.ts` :
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { migratedDb, insertUser } from './helpers.js';
+import {
+  findUserById, findUserByGoogleId, findUserByEmail, createUser,
+  updateUserProfile, upsertDevUser, findControlsConfig, updateControlsConfig,
+  searchUsers
+} from '../src/db/users.js';
+
+test('createUser generates an id and both timestamps', () => {
+  const db = migratedDb();
+  const user = createUser(db, {
+    googleId: 'g-1', email: 'a@example.test', displayName: 'Ada', avatar: null
+  });
+
+  assert.ok(user.id.length > 0, 'an id should have been generated');
+  assert.ok(user.createdAt instanceof Date);
+  assert.ok(user.updatedAt instanceof Date);
+  assert.equal(user.avatar, null);
+  assert.equal(user.controlsConfig, null);
+});
+
+test('dates come back as Date, and are integers on disk', () => {
+  const db = migratedDb();
+  const user = createUser(db, {
+    googleId: 'g-2', email: 'b@example.test', displayName: 'Bo', avatar: null
+  });
+
+  const raw = db.prepare(`SELECT typeof(createdAt) AS t FROM "User" WHERE id = ?`)
+    .get(user.id) as { t: string };
+  assert.equal(raw.t, 'integer', 'Prisma stored dates as epoch millis; so do we');
+
+  const read = findUserById(db, user.id);
+  assert.ok(read!.createdAt instanceof Date);
+  assert.equal(read!.createdAt.getTime(), user.createdAt.getTime());
+});
+
+test('findUserById returns null rather than throwing on a missing row', () => {
+  const db = migratedDb();
+  assert.equal(findUserById(db, 'nobody'), null);
+});
+
+test('findUserByGoogleId and findUserByEmail find the same row', () => {
+  const db = migratedDb();
+  const created = createUser(db, {
+    googleId: 'g-3', email: 'c@example.test', displayName: 'Cy', avatar: null
+  });
+
+  assert.equal(findUserByGoogleId(db, 'g-3')!.id, created.id);
+  assert.equal(findUserByEmail(db, 'c@example.test')!.id, created.id);
+  assert.equal(findUserByGoogleId(db, 'absent'), null);
+});
+
+test('updateUserProfile moves updatedAt forward, which Prisma used to do for us', async () => {
+  const db = migratedDb();
+  const created = createUser(db, {
+    googleId: 'g-4', email: 'd@example.test', displayName: 'Di', avatar: null
+  });
+  await new Promise(r => setTimeout(r, 5));
+
+  const updated = updateUserProfile(db, created.id, { displayName: 'Dee', avatar: 'a.png' });
+
+  assert.equal(updated.displayName, 'Dee');
+  assert.equal(updated.avatar, 'a.png');
+  assert.ok(
+    updated.updatedAt.getTime() > created.updatedAt.getTime(),
+    'updatedAt must advance: @updatedAt is gone and nothing else will do it'
+  );
+});
+
+test('upsertDevUser creates then updates only the avatar', () => {
+  const db = migratedDb();
+  const input = {
+    id: 'dev-user-1', googleId: 'dev-google-id-1',
+    email: 'user1@dev.local', displayName: 'Dev User 1', avatar: 'first.svg'
+  };
+
+  const created = upsertDevUser(db, input);
+  assert.equal(created.avatar, 'first.svg');
+
+  const updated = upsertDevUser(db, { ...input, displayName: 'Ignored', avatar: 'second.svg' });
+  assert.equal(updated.id, 'dev-user-1');
+  assert.equal(updated.avatar, 'second.svg');
+  assert.equal(updated.displayName, 'Dev User 1', 'only the avatar is refreshed, as before');
+
+  const count = db.prepare(`SELECT COUNT(*) AS n FROM "User"`).get() as { n: number };
+  assert.equal(count.n, 1);
+});
+
+test('controls config round-trips as an opaque JSON string', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+
+  assert.equal(findControlsConfig(db, user.id), null);
+
+  updateControlsConfig(db, user.id, '{"up":"ArrowUp"}');
+  assert.equal(findControlsConfig(db, user.id), '{"up":"ArrowUp"}');
+});
+
+test('searchUsers matches email or display name, excludes the caller, and caps results', () => {
+  const db = migratedDb();
+  const me = insertUser(db, { displayName: 'Searcher', email: 'me@example.test' });
+  insertUser(db, { displayName: 'Mario Fan', email: 'mario@example.test' });
+  insertUser(db, { displayName: 'Someone', email: 'zelda@example.test' });
+
+  const byName = searchUsers(db, me.id, 'Mario', 10);
+  assert.equal(byName.length, 1);
+  assert.equal(byName[0].displayName, 'Mario Fan');
+
+  const byEmail = searchUsers(db, me.id, 'zelda', 10);
+  assert.equal(byEmail.length, 1);
+
+  const self = searchUsers(db, me.id, 'Searcher', 10);
+  assert.equal(self.length, 0, 'the caller is never their own suggestion');
+
+  const capped = searchUsers(db, me.id, 'example.test', 1);
+  assert.equal(capped.length, 1);
+});
+
+test('searchUsers never exposes googleId or timestamps', () => {
+  const db = migratedDb();
+  const me = insertUser(db);
+  insertUser(db, { displayName: 'Visible' });
+
+  const [found] = searchUsers(db, me.id, 'Visible', 10);
+  assert.deepEqual(Object.keys(found).sort(), ['avatar', 'displayName', 'email', 'id']);
+});
+```
+
+- [ ] **Step 3: Lancer les tests pour les voir échouer**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+node --import tsx --test backend/test/users.test.ts
+```
+
+Attendu : ÉCHEC — `Cannot find module '../src/db/users.js'`.
+
+- [ ] **Step 4: Écrire l'implémentation**
+
+Créer `backend/src/db/users.ts` :
+
+```ts
+import { randomUUID } from 'node:crypto';
+import type { Database } from './sqlite.js';
+import type { User, UserSummary } from './types.js';
+
+interface UserRow {
+  id: string;
+  googleId: string;
+  email: string;
+  displayName: string;
+  avatar: string | null;
+  controlsConfig: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** The one place a User row becomes a User. */
+function toUser(row: UserRow): User {
+  return {
+    id: row.id,
+    googleId: row.googleId,
+    email: row.email,
+    displayName: row.displayName,
+    avatar: row.avatar,
+    controlsConfig: row.controlsConfig,
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt)
+  };
+}
+
+const SELECT = `SELECT * FROM "User"`;
+
+export function findUserById(db: Database, id: string): User | null {
+  const row = db.prepare(`${SELECT} WHERE id = ?`).get(id) as UserRow | undefined;
+  return row ? toUser(row) : null;
+}
+
+export function findUserByGoogleId(db: Database, googleId: string): User | null {
+  const row = db.prepare(`${SELECT} WHERE googleId = ?`).get(googleId) as UserRow | undefined;
+  return row ? toUser(row) : null;
+}
+
+export function findUserByEmail(db: Database, email: string): User | null {
+  const row = db.prepare(`${SELECT} WHERE email = ?`).get(email) as UserRow | undefined;
+  return row ? toUser(row) : null;
+}
+
+export function createUser(
+  db: Database,
+  input: { googleId: string; email: string; displayName: string; avatar: string | null }
+): User {
+  const id = randomUUID();
+  const now = Date.now();
+  db.prepare(`
+    INSERT INTO "User" (id, googleId, email, displayName, avatar, controlsConfig, createdAt, updatedAt)
+    VALUES (?, ?, ?, ?, ?, NULL, ?, ?)
+  `).run(id, input.googleId, input.email, input.displayName, input.avatar, now, now);
+  return findUserById(db, id)!;
+}
+
+export function updateUserProfile(
+  db: Database,
+  id: string,
+  input: { displayName: string; avatar: string | null }
+): User {
+  db.prepare(`
+    UPDATE "User" SET displayName = ?, avatar = ?, updatedAt = ? WHERE id = ?
+  `).run(input.displayName, input.avatar, Date.now(), id);
+  return findUserById(db, id)!;
+}
+
+/**
+ * The dev-login shortcut. Creates the fixed dev user, or refreshes nothing but
+ * its avatar - matching what the Prisma upsert did.
+ */
+export function upsertDevUser(
+  db: Database,
+  input: { id: string; googleId: string; email: string; displayName: string; avatar: string }
+): User {
+  const now = Date.now();
+  db.prepare(`
+    INSERT INTO "User" (id, googleId, email, displayName, avatar, controlsConfig, createdAt, updatedAt)
+    VALUES (@id, @googleId, @email, @displayName, @avatar, NULL, @now, @now)
+    ON CONFLICT(id) DO UPDATE SET avatar = @avatar, updatedAt = @now
+  `).run({ ...input, now });
+  return findUserById(db, input.id)!;
+}
+
+export function findControlsConfig(db: Database, userId: string): string | null {
+  const row = db.prepare(`SELECT controlsConfig FROM "User" WHERE id = ?`)
+    .get(userId) as { controlsConfig: string | null } | undefined;
+  return row?.controlsConfig ?? null;
+}
+
+export function updateControlsConfig(db: Database, userId: string, json: string): void {
+  db.prepare(`UPDATE "User" SET controlsConfig = ?, updatedAt = ? WHERE id = ?`)
+    .run(json, Date.now(), userId);
+}
+
+/**
+ * Friend suggestions. Returns only what the client is allowed to see - never
+ * googleId, never the timestamps - which the old `select:` clause guaranteed
+ * and a `SELECT *` would quietly give away.
+ */
+export function searchUsers(
+  db: Database,
+  excludeUserId: string,
+  query: string,
+  limit: number
+): UserSummary[] {
+  return db.prepare(`
+    SELECT id, email, displayName, avatar FROM "User"
+    WHERE id != ?
+      AND (email LIKE '%' || ? || '%' OR displayName LIKE '%' || ? || '%')
+    LIMIT ?
+  `).all(excludeUserId, query, query, limit) as UserSummary[];
+}
+```
+
+Les fonctions prennent `db` en premier paramètre plutôt que d'appeler `getDb()` elles-mêmes : c'est ce qui rend les tests possibles sans variable d'environnement ni singleton à réinitialiser.
+
+- [ ] **Step 5: Lancer les tests pour les voir passer**
+
+```bash
+node --import tsx --test backend/test/users.test.ts
+```
+
+Attendu : 9 tests passants.
+
+- [ ] **Step 6: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/db/users.ts backend/test/users.test.ts backend/test/helpers.ts
+git commit -m "Give users a repository that hands back Dates and hides googleId"
+```
+
+### Task 9: Le dépôt des amitiés, avec ses quatre jointures
+
+**Files:**
+- Create: `backend/src/db/friendships.ts`
+- Create: `backend/test/friendships.test.ts`
+
+**Interfaces:**
+- Consumes: `Database`, `User`, `Friendship` ; `insertUser` du harnais
+- Produces:
+  - `interface FriendshipWithProfiles extends Friendship { initiator: User; receiver: User }`
+  - `interface FriendshipWithInitiator extends Friendship { initiator: User }`
+  - `listAcceptedFriendshipsFor(db, userId): Friendship[]`
+  - `listAcceptedFriendshipsWithProfiles(db, userId): FriendshipWithProfiles[]`
+  - `listPendingRequestsFor(db, userId): FriendshipWithInitiator[]`
+  - `listFriendshipPairsFor(db, userId): { initiatorId: string; receiverId: string; status: string }[]`
+  - `findFriendshipById(db, id): Friendship | null`
+  - `findFriendshipBetween(db, a, b): Friendship | null`
+  - `createFriendshipRequest(db, initiatorId, receiverId): FriendshipWithProfiles`
+  - `acceptFriendship(db, id): FriendshipWithProfiles`
+  - `deleteFriendship(db, id): void`
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `backend/test/friendships.test.ts` :
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { migratedDb, insertUser } from './helpers.js';
+import {
+  listAcceptedFriendshipsFor, listAcceptedFriendshipsWithProfiles,
+  listPendingRequestsFor, listFriendshipPairsFor, findFriendshipById,
+  findFriendshipBetween, createFriendshipRequest, acceptFriendship, deleteFriendship
+} from '../src/db/friendships.js';
+
+test('a new request is pending, and findable from either side', () => {
+  const db = migratedDb();
+  const ada = insertUser(db, { displayName: 'Ada' });
+  const bo = insertUser(db, { displayName: 'Bo' });
+
+  const created = createFriendshipRequest(db, ada.id, bo.id);
+
+  assert.equal(created.status, 'pending');
+  assert.ok(created.id.length > 0);
+  assert.equal(findFriendshipBetween(db, ada.id, bo.id)!.id, created.id);
+  assert.equal(findFriendshipBetween(db, bo.id, ada.id)!.id, created.id,
+    'the pair is unordered: a request in either direction is the same friendship');
+  assert.equal(findFriendshipBetween(db, ada.id, 'stranger'), null);
+});
+
+test('createFriendshipRequest returns both profiles nested, as the callers destructure them', () => {
+  const db = migratedDb();
+  const ada = insertUser(db, { displayName: 'Ada' });
+  const bo = insertUser(db, { displayName: 'Bo' });
+
+  const created = createFriendshipRequest(db, ada.id, bo.id);
+
+  assert.equal(created.initiator.displayName, 'Ada');
+  assert.equal(created.receiver.displayName, 'Bo');
+  assert.ok(created.initiator.createdAt instanceof Date);
+});
+
+test('pending requests list only those received, with the initiator attached', () => {
+  const db = migratedDb();
+  const ada = insertUser(db, { displayName: 'Ada' });
+  const bo = insertUser(db, { displayName: 'Bo' });
+  const cy = insertUser(db, { displayName: 'Cy' });
+
+  createFriendshipRequest(db, ada.id, bo.id);   // Bo receives
+  createFriendshipRequest(db, bo.id, cy.id);    // Bo sends
+
+  const requests = listPendingRequestsFor(db, bo.id);
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].initiator.displayName, 'Ada');
+});
+
+test('accepting moves the status and advances updatedAt', async () => {
+  const db = migratedDb();
+  const ada = insertUser(db, { displayName: 'Ada' });
+  const bo = insertUser(db, { displayName: 'Bo' });
+  const created = createFriendshipRequest(db, ada.id, bo.id);
+  await new Promise(r => setTimeout(r, 5));
+
+  const accepted = acceptFriendship(db, created.id);
+
+  assert.equal(accepted.status, 'accepted');
+  assert.ok(accepted.updatedAt.getTime() > created.updatedAt.getTime(),
+    'the friends list shows updatedAt as "friends since"; it has to move');
+  assert.equal(accepted.initiator.displayName, 'Ada');
+  assert.equal(accepted.receiver.displayName, 'Bo');
+});
+
+test('accepted friendships are listed from both sides, pending ones are not', () => {
+  const db = migratedDb();
+  const ada = insertUser(db, { displayName: 'Ada' });
+  const bo = insertUser(db, { displayName: 'Bo' });
+  const cy = insertUser(db, { displayName: 'Cy' });
+
+  const accepted = createFriendshipRequest(db, ada.id, bo.id);
+  acceptFriendship(db, accepted.id);
+  createFriendshipRequest(db, ada.id, cy.id); // stays pending
+
+  assert.equal(listAcceptedFriendshipsFor(db, ada.id).length, 1);
+  assert.equal(listAcceptedFriendshipsFor(db, bo.id).length, 1);
+  assert.equal(listAcceptedFriendshipsFor(db, cy.id).length, 0);
+});
+
+test('the profile-carrying list gives both sides, whichever end you are', () => {
+  const db = migratedDb();
+  const ada = insertUser(db, { displayName: 'Ada' });
+  const bo = insertUser(db, { displayName: 'Bo' });
+  acceptFriendship(db, createFriendshipRequest(db, ada.id, bo.id).id);
+
+  const [fromBo] = listAcceptedFriendshipsWithProfiles(db, bo.id);
+
+  assert.equal(fromBo.initiator.displayName, 'Ada');
+  assert.equal(fromBo.receiver.displayName, 'Bo');
+  assert.equal(fromBo.initiatorId, ada.id);
+});
+
+test('listFriendshipPairsFor returns every link regardless of status', () => {
+  const db = migratedDb();
+  const ada = insertUser(db);
+  const bo = insertUser(db);
+  const cy = insertUser(db);
+  acceptFriendship(db, createFriendshipRequest(db, ada.id, bo.id).id);
+  createFriendshipRequest(db, ada.id, cy.id);
+
+  const pairs = listFriendshipPairsFor(db, ada.id);
+
+  assert.equal(pairs.length, 2, 'search filters out pending links too, so they must be here');
+  assert.deepEqual(Object.keys(pairs[0]).sort(), ['initiatorId', 'receiverId', 'status']);
+});
+
+test('deleting removes the row and leaves both users standing', () => {
+  const db = migratedDb();
+  const ada = insertUser(db);
+  const bo = insertUser(db);
+  const created = createFriendshipRequest(db, ada.id, bo.id);
+
+  deleteFriendship(db, created.id);
+
+  assert.equal(findFriendshipById(db, created.id), null);
+  const users = db.prepare(`SELECT COUNT(*) AS n FROM "User"`).get() as { n: number };
+  assert.equal(users.n, 2);
+});
+
+test('deleting a user cascades their friendships away', () => {
+  const db = migratedDb();
+  const ada = insertUser(db);
+  const bo = insertUser(db);
+  createFriendshipRequest(db, ada.id, bo.id);
+
+  db.prepare(`DELETE FROM "User" WHERE id = ?`).run(ada.id);
+
+  const left = db.prepare(`SELECT COUNT(*) AS n FROM "Friendship"`).get() as { n: number };
+  assert.equal(left.n, 0, 'onDelete: Cascade only works with foreign_keys ON');
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour les voir échouer**
+
+```bash
+node --import tsx --test backend/test/friendships.test.ts
+```
+
+Attendu : ÉCHEC — module introuvable.
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Créer `backend/src/db/friendships.ts` :
+
+```ts
+import { randomUUID } from 'node:crypto';
+import type { Database } from './sqlite.js';
+import type { Friendship, User } from './types.js';
+
+export interface FriendshipWithProfiles extends Friendship {
+  initiator: User;
+  receiver: User;
+}
+
+export interface FriendshipWithInitiator extends Friendship {
+  initiator: User;
+}
+
+interface FriendshipRow {
+  id: string;
+  status: string;
+  createdAt: number;
+  updatedAt: number;
+  initiatorId: string;
+  receiverId: string;
+}
+
+function toFriendship(row: FriendshipRow): Friendship {
+  return {
+    id: row.id,
+    status: row.status,
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt),
+    initiatorId: row.initiatorId,
+    receiverId: row.receiverId
+  };
+}
+
+/**
+ * The joins used to come back as nested objects, and the callers read them that
+ * way - `f.initiator.displayName`. A flat row would mean changing every caller,
+ * so the nesting is rebuilt here instead, once.
+ *
+ * Columns are aliased with a prefix rather than selected as `u.*`, because
+ * User and Friendship both have `id`, `createdAt` and `updatedAt`.
+ */
+const USER_COLUMNS = (alias: string, prefix: string) => `
+  ${alias}.id AS ${prefix}_id,
+  ${alias}.googleId AS ${prefix}_googleId,
+  ${alias}.email AS ${prefix}_email,
+  ${alias}.displayName AS ${prefix}_displayName,
+  ${alias}.avatar AS ${prefix}_avatar,
+  ${alias}.controlsConfig AS ${prefix}_controlsConfig,
+  ${alias}.createdAt AS ${prefix}_createdAt,
+  ${alias}.updatedAt AS ${prefix}_updatedAt
+`;
+
+function toUserFrom(row: Record<string, unknown>, prefix: string): User {
+  return {
+    id: row[`${prefix}_id`] as string,
+    googleId: row[`${prefix}_googleId`] as string,
+    email: row[`${prefix}_email`] as string,
+    displayName: row[`${prefix}_displayName`] as string,
+    avatar: (row[`${prefix}_avatar`] as string | null) ?? null,
+    controlsConfig: (row[`${prefix}_controlsConfig`] as string | null) ?? null,
+    createdAt: new Date(row[`${prefix}_createdAt`] as number),
+    updatedAt: new Date(row[`${prefix}_updatedAt`] as number)
+  };
+}
+
+function toFriendshipBase(row: Record<string, unknown>): Friendship {
+  return toFriendship({
+    id: row.id as string,
+    status: row.status as string,
+    createdAt: row.createdAt as number,
+    updatedAt: row.updatedAt as number,
+    initiatorId: row.initiatorId as string,
+    receiverId: row.receiverId as string
+  });
+}
+
+const BOTH_PROFILES = `
+  SELECT f.*,
+    ${USER_COLUMNS('i', 'i')},
+    ${USER_COLUMNS('r', 'r')}
+  FROM "Friendship" f
+  JOIN "User" i ON i.id = f.initiatorId
+  JOIN "User" r ON r.id = f.receiverId
+`;
+
+function toWithProfiles(row: Record<string, unknown>): FriendshipWithProfiles {
+  return {
+    ...toFriendshipBase(row),
+    initiator: toUserFrom(row, 'i'),
+    receiver: toUserFrom(row, 'r')
+  };
+}
+
+export function listAcceptedFriendshipsFor(db: Database, userId: string): Friendship[] {
+  const rows = db.prepare(`
+    SELECT * FROM "Friendship"
+    WHERE (initiatorId = ? OR receiverId = ?) AND status = 'accepted'
+  `).all(userId, userId) as FriendshipRow[];
+  return rows.map(toFriendship);
+}
+
+export function listAcceptedFriendshipsWithProfiles(
+  db: Database,
+  userId: string
+): FriendshipWithProfiles[] {
+  const rows = db.prepare(`
+    ${BOTH_PROFILES}
+    WHERE (f.initiatorId = ? OR f.receiverId = ?) AND f.status = 'accepted'
+  `).all(userId, userId) as Record<string, unknown>[];
+  return rows.map(toWithProfiles);
+}
+
+export function listPendingRequestsFor(db: Database, userId: string): FriendshipWithInitiator[] {
+  const rows = db.prepare(`
+    SELECT f.*, ${USER_COLUMNS('i', 'i')}
+    FROM "Friendship" f
+    JOIN "User" i ON i.id = f.initiatorId
+    WHERE f.receiverId = ? AND f.status = 'pending'
+  `).all(userId) as Record<string, unknown>[];
+  return rows.map(row => ({ ...toFriendshipBase(row), initiator: toUserFrom(row, 'i') }));
+}
+
+export function listFriendshipPairsFor(
+  db: Database,
+  userId: string
+): { initiatorId: string; receiverId: string; status: string }[] {
+  return db.prepare(`
+    SELECT initiatorId, receiverId, status FROM "Friendship"
+    WHERE initiatorId = ? OR receiverId = ?
+  `).all(userId, userId) as { initiatorId: string; receiverId: string; status: string }[];
+}
+
+export function findFriendshipById(db: Database, id: string): Friendship | null {
+  const row = db.prepare(`SELECT * FROM "Friendship" WHERE id = ?`).get(id) as FriendshipRow | undefined;
+  return row ? toFriendship(row) : null;
+}
+
+export function findFriendshipBetween(db: Database, a: string, b: string): Friendship | null {
+  const row = db.prepare(`
+    SELECT * FROM "Friendship"
+    WHERE (initiatorId = ? AND receiverId = ?) OR (initiatorId = ? AND receiverId = ?)
+  `).get(a, b, b, a) as FriendshipRow | undefined;
+  return row ? toFriendship(row) : null;
+}
+
+function findWithProfiles(db: Database, id: string): FriendshipWithProfiles {
+  const row = db.prepare(`${BOTH_PROFILES} WHERE f.id = ?`).get(id) as Record<string, unknown>;
+  return toWithProfiles(row);
+}
+
+export function createFriendshipRequest(
+  db: Database,
+  initiatorId: string,
+  receiverId: string
+): FriendshipWithProfiles {
+  const id = randomUUID();
+  const now = Date.now();
+  db.prepare(`
+    INSERT INTO "Friendship" (id, status, createdAt, updatedAt, initiatorId, receiverId)
+    VALUES (?, 'pending', ?, ?, ?, ?)
+  `).run(id, now, now, initiatorId, receiverId);
+  return findWithProfiles(db, id);
+}
+
+export function acceptFriendship(db: Database, id: string): FriendshipWithProfiles {
+  db.prepare(`UPDATE "Friendship" SET status = 'accepted', updatedAt = ? WHERE id = ?`)
+    .run(Date.now(), id);
+  return findWithProfiles(db, id);
+}
+
+export function deleteFriendship(db: Database, id: string): void {
+  db.prepare(`DELETE FROM "Friendship" WHERE id = ?`).run(id);
+}
+```
+
+- [ ] **Step 4: Lancer les tests pour les voir passer**
+
+```bash
+node --import tsx --test backend/test/friendships.test.ts
+```
+
+Attendu : 9 tests passants.
+
+- [ ] **Step 5: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/db/friendships.ts backend/test/friendships.test.ts
+git commit -m "Rebuild the friendship joins the callers already destructure"
+```
+
+### Task 10: Le dépôt des jeux
+
+**Files:**
+- Create: `backend/src/db/games.ts`
+- Create: `backend/test/games.test.ts`
+
+**Interfaces:**
+- Consumes: `Database`, `Game`, `SaveSummary`, `Save`
+- Produces:
+  - `interface GameWithSaveSummaries extends Game { saves: SaveSummary[] }`
+  - `interface GameWithSaves extends Game { saves: Save[] }`
+  - `interface GameDescriptiveFields { genre: string | null; publisher: string | null; developer: string | null; releaseDate: string | null; players: string | null; region: string | null; description: string | null; coverUrl: string | null }`
+  - `interface GameMetadataFields extends GameDescriptiveFields { title: string }`
+  - `listGamesWithSaveSummaries(db, userId): GameWithSaveSummaries[]`
+  - `listGamesFor(db, userId): Game[]`
+  - `findGameById(db, id): Game | null`
+  - `findGameWithSaves(db, id): GameWithSaves | null`
+  - `findGameByChecksum(db, userId, crc32): Game | null`
+  - `findOtherGameWithChecksum(db, userId, crc32, excludeGameId): Game | null`
+  - `countGamesFor(db, userId): number`
+  - `createGame(db, input: { title: string; filename: string; crc32: string | null; userId: string } & GameDescriptiveFields): Game`
+  - `updateGameChecksum(db, id, crc32): Game`
+  - `updateGameMetadata(db, id, fields: GameMetadataFields): void`
+  - `deleteGame(db, id): void`
+  - `findOwnedGameId(db, gameId, userId): string | null`
+  - `findChecksumOfOwnedGame(db, gameId, userId): string | null`
+  - `saveSram(db, gameId, userId, sram: Buffer): void`
+  - `findSram(db, gameId, userId): { sram: Buffer; sramUpdatedAt: Date | null } | null`
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `backend/test/games.test.ts` :
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { migratedDb, insertUser } from './helpers.js';
+import {
+  listGamesWithSaveSummaries, listGamesFor, findGameById, findGameWithSaves,
+  findGameByChecksum, findOtherGameWithChecksum, countGamesFor, createGame,
+  updateGameChecksum, updateGameMetadata, deleteGame, findOwnedGameId,
+  findChecksumOfOwnedGame, saveSram, findSram
+} from '../src/db/games.js';
+import { createSave } from '../src/db/saves.js';
+
+const NO_METADATA = {
+  genre: null, publisher: null, developer: null, releaseDate: null,
+  players: null, region: null, description: null, coverUrl: null
+};
+
+test('createGame stamps an id and uploadedAt, and defaults the rest to null', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+
+  const game = createGame(db, {
+    title: 'Super Metroid', filename: 'sm.sfc', crc32: 'DEADBEEF',
+    userId: user.id, ...NO_METADATA
+  });
+
+  assert.ok(game.id.length > 0);
+  assert.ok(game.uploadedAt instanceof Date);
+  assert.equal(game.sram, null);
+  assert.equal(game.sramUpdatedAt, null);
+  assert.equal(game.genre, null);
+});
+
+test('a library lists newest first, with save summaries but never save blobs', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const older = createGame(db, { title: 'A', filename: 'a.sfc', crc32: 'AAAAAAAA', userId: user.id, ...NO_METADATA });
+  const newer = createGame(db, { title: 'B', filename: 'b.sfc', crc32: 'BBBBBBBB', userId: user.id, ...NO_METADATA });
+  db.prepare(`UPDATE "Game" SET uploadedAt = ? WHERE id = ?`).run(1_000, older.id);
+  db.prepare(`UPDATE "Game" SET uploadedAt = ? WHERE id = ?`).run(2_000, newer.id);
+  createSave(db, { gameId: newer.id, slotNumber: 1, name: 'slot one', data: Buffer.from([1, 2, 3]), screenshot: null });
+
+  const library = listGamesWithSaveSummaries(db, user.id);
+
+  assert.deepEqual(library.map(g => g.title), ['B', 'A']);
+  assert.equal(library[0].saves.length, 1);
+  assert.equal(library[0].saves[0].name, 'slot one');
+  assert.ok(!('data' in library[0].saves[0]), 'a library listing must not carry savestate blobs');
+  assert.ok(library[0].saves[0].createdAt instanceof Date);
+  assert.deepEqual(library[1].saves, []);
+});
+
+test('a library shows only the caller games', () => {
+  const db = migratedDb();
+  const mine = insertUser(db);
+  const theirs = insertUser(db);
+  createGame(db, { title: 'Mine', filename: 'm.sfc', crc32: 'AAAAAAAA', userId: mine.id, ...NO_METADATA });
+  createGame(db, { title: 'Theirs', filename: 't.sfc', crc32: 'BBBBBBBB', userId: theirs.id, ...NO_METADATA });
+
+  assert.equal(listGamesWithSaveSummaries(db, mine.id).length, 1);
+  assert.equal(listGamesFor(db, mine.id).length, 1);
+  assert.equal(countGamesFor(db, mine.id), 1);
+});
+
+test('a checksum finds a game within its owner library only', () => {
+  const db = migratedDb();
+  const mine = insertUser(db);
+  const theirs = insertUser(db);
+  createGame(db, { title: 'Mine', filename: 'm.sfc', crc32: 'DEADBEEF', userId: mine.id, ...NO_METADATA });
+
+  assert.ok(findGameByChecksum(db, mine.id, 'DEADBEEF'));
+  assert.equal(findGameByChecksum(db, theirs.id, 'DEADBEEF'), null);
+});
+
+test('re-linking a checksum detects a clash with another of your games', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const first = createGame(db, { title: 'First', filename: 'f.sfc', crc32: 'DEADBEEF', userId: user.id, ...NO_METADATA });
+  const second = createGame(db, { title: 'Second', filename: 's.sfc', crc32: null, userId: user.id, ...NO_METADATA });
+
+  assert.equal(findOtherGameWithChecksum(db, user.id, 'DEADBEEF', second.id)!.id, first.id);
+  assert.equal(findOtherGameWithChecksum(db, user.id, 'DEADBEEF', first.id), null,
+    'a game never clashes with itself');
+
+  const updated = updateGameChecksum(db, second.id, 'CAFEBABE');
+  assert.equal(updated.crc32, 'CAFEBABE');
+});
+
+test('metadata refresh overwrites the descriptive fields', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const game = createGame(db, { title: 'Rough Name', filename: 'g.sfc', crc32: 'AAAAAAAA', userId: user.id, ...NO_METADATA });
+
+  updateGameMetadata(db, game.id, {
+    title: 'Proper Name', genre: 'Action', publisher: 'Nintendo', developer: 'Nintendo R&D1',
+    releaseDate: '1994-03-19', players: '1', region: 'NTSC', description: 'A game', coverUrl: 'c.png'
+  });
+
+  const read = findGameById(db, game.id)!;
+  assert.equal(read.title, 'Proper Name');
+  assert.equal(read.genre, 'Action');
+  assert.equal(read.coverUrl, 'c.png');
+});
+
+test('deleting a game takes its saves with it', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const game = createGame(db, { title: 'G', filename: 'g.sfc', crc32: 'AAAAAAAA', userId: user.id, ...NO_METADATA });
+  createSave(db, { gameId: game.id, slotNumber: 1, name: 's', data: Buffer.from([1]), screenshot: null });
+
+  deleteGame(db, game.id);
+
+  assert.equal(findGameById(db, game.id), null);
+  const saves = db.prepare(`SELECT COUNT(*) AS n FROM "Save"`).get() as { n: number };
+  assert.equal(saves.n, 0, 'the server never held the ROM, but the saves must go');
+});
+
+test('findGameWithSaves nests the full saves, blobs included', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const game = createGame(db, { title: 'G', filename: 'g.sfc', crc32: 'AAAAAAAA', userId: user.id, ...NO_METADATA });
+  createSave(db, { gameId: game.id, slotNumber: 2, name: 's', data: Buffer.from([9, 8, 7]), screenshot: null });
+
+  const found = findGameWithSaves(db, game.id)!;
+
+  assert.equal(found.saves.length, 1);
+  assert.ok(Buffer.isBuffer(found.saves[0].data));
+  assert.deepEqual([...found.saves[0].data], [9, 8, 7]);
+});
+
+test('ownership checks refuse a game that is not yours', () => {
+  const db = migratedDb();
+  const mine = insertUser(db);
+  const theirs = insertUser(db);
+  const game = createGame(db, { title: 'G', filename: 'g.sfc', crc32: 'DEADBEEF', userId: mine.id, ...NO_METADATA });
+
+  assert.equal(findOwnedGameId(db, game.id, mine.id), game.id);
+  assert.equal(findOwnedGameId(db, game.id, theirs.id), null);
+  assert.equal(findChecksumOfOwnedGame(db, game.id, mine.id), 'DEADBEEF');
+  assert.equal(findChecksumOfOwnedGame(db, game.id, theirs.id), null);
+});
+
+test('SRAM round-trips as a Buffer and stamps its own timestamp', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const game = createGame(db, { title: 'G', filename: 'g.sfc', crc32: 'AAAAAAAA', userId: user.id, ...NO_METADATA });
+
+  assert.equal(findSram(db, game.id, user.id), null, 'no SRAM yet');
+
+  const bytes = Buffer.alloc(8192, 0x5a);
+  saveSram(db, game.id, user.id, bytes);
+
+  const read = findSram(db, game.id, user.id)!;
+  assert.ok(Buffer.isBuffer(read.sram));
+  assert.equal(read.sram.length, 8192);
+  assert.equal(read.sram[0], 0x5a);
+  assert.ok(read.sramUpdatedAt instanceof Date);
+});
+
+test('SRAM writes refuse a game that is not yours', () => {
+  const db = migratedDb();
+  const mine = insertUser(db);
+  const theirs = insertUser(db);
+  const game = createGame(db, { title: 'G', filename: 'g.sfc', crc32: 'AAAAAAAA', userId: mine.id, ...NO_METADATA });
+
+  saveSram(db, game.id, theirs.id, Buffer.from([1, 2, 3]));
+
+  assert.equal(findSram(db, game.id, mine.id), null, 'the write must not have landed');
+});
+
+test('a large savestate blob survives the round trip intact', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const game = createGame(db, { title: 'G', filename: 'g.sfc', crc32: 'AAAAAAAA', userId: user.id, ...NO_METADATA });
+  // Savestates run around 823KB; check the real order of magnitude, not a toy.
+  const big = Buffer.alloc(900_000);
+  for (let i = 0; i < big.length; i++) big[i] = i % 256;
+  createSave(db, { gameId: game.id, slotNumber: 1, name: 'big', data: big, screenshot: null });
+
+  const read = findGameWithSaves(db, game.id)!.saves[0];
+
+  assert.equal(read.data.length, big.length);
+  assert.ok(read.data.equals(big), 'the blob must come back byte for byte');
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour les voir échouer**
+
+```bash
+node --import tsx --test backend/test/games.test.ts
+```
+
+Attendu : ÉCHEC — `backend/src/db/games.js` et `backend/src/db/saves.js` introuvables. La Task 11 écrit le second ; l'implémenter d'abord si l'on préfère un rouge plus net, ou accepter que ce fichier de test ne devienne vert qu'à la fin de la Task 11.
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Créer `backend/src/db/games.ts` :
+
+```ts
+import { randomUUID } from 'node:crypto';
+import type { Database } from './sqlite.js';
+import type { Game, Save, SaveSummary } from './types.js';
+
+export interface GameWithSaveSummaries extends Game {
+  saves: SaveSummary[];
+}
+
+export interface GameWithSaves extends Game {
+  saves: Save[];
+}
+
+/** The descriptive columns, which a metadata match fills in and a bare add leaves null. */
+export interface GameDescriptiveFields {
+  genre: string | null;
+  publisher: string | null;
+  developer: string | null;
+  releaseDate: string | null;
+  players: string | null;
+  region: string | null;
+  description: string | null;
+  coverUrl: string | null;
+}
+
+/** A metadata refresh also rewrites the title, which creation takes separately. */
+export interface GameMetadataFields extends GameDescriptiveFields {
+  title: string;
+}
+
+interface GameRow {
+  id: string;
+  title: string;
+  filename: string;
+  coverUrl: string | null;
+  uploadedAt: number;
+  genre: string | null;
+  publisher: string | null;
+  developer: string | null;
+  releaseDate: string | null;
+  players: string | null;
+  region: string | null;
+  description: string | null;
+  crc32: string | null;
+  sram: Buffer | null;
+  sramUpdatedAt: number | null;
+  userId: string;
+}
+
+function toGame(row: GameRow): Game {
+  return {
+    id: row.id,
+    title: row.title,
+    filename: row.filename,
+    coverUrl: row.coverUrl,
+    uploadedAt: new Date(row.uploadedAt),
+    genre: row.genre,
+    publisher: row.publisher,
+    developer: row.developer,
+    releaseDate: row.releaseDate,
+    players: row.players,
+    region: row.region,
+    description: row.description,
+    crc32: row.crc32,
+    sram: row.sram,
+    sramUpdatedAt: row.sramUpdatedAt === null ? null : new Date(row.sramUpdatedAt),
+    userId: row.userId
+  };
+}
+
+export function findGameById(db: Database, id: string): Game | null {
+  const row = db.prepare(`SELECT * FROM "Game" WHERE id = ?`).get(id) as GameRow | undefined;
+  return row ? toGame(row) : null;
+}
+
+export function listGamesFor(db: Database, userId: string): Game[] {
+  const rows = db.prepare(`SELECT * FROM "Game" WHERE userId = ?`).all(userId) as GameRow[];
+  return rows.map(toGame);
+}
+
+/**
+ * The library listing. Saves come back as summaries: the blob is up to a
+ * megabyte per slot and the listing never used it.
+ */
+export function listGamesWithSaveSummaries(db: Database, userId: string): GameWithSaveSummaries[] {
+  const games = db.prepare(`SELECT * FROM "Game" WHERE userId = ? ORDER BY uploadedAt DESC`)
+    .all(userId) as GameRow[];
+  if (games.length === 0) return [];
+
+  const summaries = db.prepare(`
+    SELECT id, name, slotNumber, screenshot, createdAt, updatedAt, gameId
+    FROM "Save" WHERE gameId IN (${games.map(() => '?').join(',')})
+  `).all(...games.map(g => g.id)) as (Omit<SaveSummary, 'createdAt' | 'updatedAt'> & {
+    createdAt: number; updatedAt: number; gameId: string;
+  })[];
+
+  const byGame = new Map<string, SaveSummary[]>();
+  for (const s of summaries) {
+    const list = byGame.get(s.gameId) ?? [];
+    list.push({
+      id: s.id,
+      name: s.name,
+      slotNumber: s.slotNumber,
+      screenshot: s.screenshot,
+      createdAt: new Date(s.createdAt),
+      updatedAt: new Date(s.updatedAt)
+    });
+    byGame.set(s.gameId, list);
+  }
+
+  return games.map(g => ({ ...toGame(g), saves: byGame.get(g.id) ?? [] }));
+}
+
+export function findGameWithSaves(db: Database, id: string): GameWithSaves | null {
+  const game = findGameById(db, id);
+  if (!game) return null;
+  const rows = db.prepare(`SELECT * FROM "Save" WHERE gameId = ?`).all(id) as {
+    id: string; name: string; slotNumber: number; data: Buffer; screenshot: string | null;
+    createdAt: number; updatedAt: number; gameId: string;
+  }[];
+  return {
+    ...game,
+    saves: rows.map(r => ({
+      id: r.id,
+      name: r.name,
+      slotNumber: r.slotNumber,
+      data: r.data,
+      screenshot: r.screenshot,
+      createdAt: new Date(r.createdAt),
+      updatedAt: new Date(r.updatedAt),
+      gameId: r.gameId
+    }))
+  };
+}
+
+export function findGameByChecksum(db: Database, userId: string, crc32: string): Game | null {
+  const row = db.prepare(`SELECT * FROM "Game" WHERE userId = ? AND crc32 = ?`)
+    .get(userId, crc32) as GameRow | undefined;
+  return row ? toGame(row) : null;
+}
+
+export function findOtherGameWithChecksum(
+  db: Database, userId: string, crc32: string, excludeGameId: string
+): Game | null {
+  const row = db.prepare(`SELECT * FROM "Game" WHERE userId = ? AND crc32 = ? AND id != ?`)
+    .get(userId, crc32, excludeGameId) as GameRow | undefined;
+  return row ? toGame(row) : null;
+}
+
+export function countGamesFor(db: Database, userId: string): number {
+  const row = db.prepare(`SELECT COUNT(*) AS n FROM "Game" WHERE userId = ?`)
+    .get(userId) as { n: number };
+  return row.n;
+}
+
+export function createGame(
+  db: Database,
+  input: { title: string; filename: string; crc32: string | null; userId: string } & GameDescriptiveFields
+): Game {
+  const id = randomUUID();
+  db.prepare(`
+    INSERT INTO "Game" (id, title, filename, coverUrl, uploadedAt, genre, publisher,
+                        developer, releaseDate, players, region, description, crc32,
+                        sram, sramUpdatedAt, userId)
+    VALUES (@id, @title, @filename, @coverUrl, @uploadedAt, @genre, @publisher,
+            @developer, @releaseDate, @players, @region, @description, @crc32,
+            NULL, NULL, @userId)
+  `).run({
+    id,
+    title: input.title,
+    filename: input.filename,
+    coverUrl: input.coverUrl,
+    uploadedAt: Date.now(),
+    genre: input.genre,
+    publisher: input.publisher,
+    developer: input.developer,
+    releaseDate: input.releaseDate,
+    players: input.players,
+    region: input.region,
+    description: input.description,
+    crc32: input.crc32,
+    userId: input.userId
+  });
+  return findGameById(db, id)!;
+}
+
+export function updateGameChecksum(db: Database, id: string, crc32: string): Game {
+  db.prepare(`UPDATE "Game" SET crc32 = ? WHERE id = ?`).run(crc32, id);
+  return findGameById(db, id)!;
+}
+
+export function updateGameMetadata(db: Database, id: string, fields: GameMetadataFields): void {
+  db.prepare(`
+    UPDATE "Game" SET
+      title = @title, genre = @genre, publisher = @publisher,
+      developer = @developer, releaseDate = @releaseDate, players = @players,
+      region = @region, description = @description, coverUrl = @coverUrl
+    WHERE id = @id
+  `).run({
+    id,
+    title: fields.title,
+    genre: fields.genre,
+    publisher: fields.publisher,
+    developer: fields.developer,
+    releaseDate: fields.releaseDate,
+    players: fields.players,
+    region: fields.region,
+    description: fields.description,
+    coverUrl: fields.coverUrl
+  });
+}
+
+export function deleteGame(db: Database, id: string): void {
+  db.prepare(`DELETE FROM "Game" WHERE id = ?`).run(id);
+}
+
+/** Ownership check for the save path: returns the id only if the game is theirs. */
+export function findOwnedGameId(db: Database, gameId: string, userId: string): string | null {
+  const row = db.prepare(`SELECT id FROM "Game" WHERE id = ? AND userId = ?`)
+    .get(gameId, userId) as { id: string } | undefined;
+  return row?.id ?? null;
+}
+
+export function findChecksumOfOwnedGame(db: Database, gameId: string, userId: string): string | null {
+  const row = db.prepare(`SELECT crc32 FROM "Game" WHERE id = ? AND userId = ?`)
+    .get(gameId, userId) as { crc32: string | null } | undefined;
+  return row?.crc32 ?? null;
+}
+
+export function saveSram(db: Database, gameId: string, userId: string, sram: Buffer): void {
+  db.prepare(`UPDATE "Game" SET sram = ?, sramUpdatedAt = ? WHERE id = ? AND userId = ?`)
+    .run(sram, Date.now(), gameId, userId);
+}
+
+export function findSram(
+  db: Database, gameId: string, userId: string
+): { sram: Buffer; sramUpdatedAt: Date | null } | null {
+  const row = db.prepare(`SELECT sram, sramUpdatedAt FROM "Game" WHERE id = ? AND userId = ?`)
+    .get(gameId, userId) as { sram: Buffer | null; sramUpdatedAt: number | null } | undefined;
+  if (!row?.sram) return null;
+  return {
+    sram: row.sram,
+    sramUpdatedAt: row.sramUpdatedAt === null ? null : new Date(row.sramUpdatedAt)
+  };
+}
+```
+
+**Note sur les deux types de champs.** `createGame` prend `GameDescriptiveFields` (sans titre : la création reçoit son titre à part, parce qu'il peut venir du nom de fichier plutôt que des métadonnées), tandis que `updateGameMetadata` prend `GameMetadataFields`, qui ajoute le titre — un rafraîchissement de métadonnées réécrit bien le titre, c'est son intérêt principal. Les paramètres sont énumérés un par un dans les deux fonctions plutôt que passés par spread : un champ oublié devient alors une erreur de compilation au lieu d'une colonne laissée à sa valeur par défaut.
+
+- [ ] **Step 4: Lancer les tests pour les voir passer**
+
+```bash
+node --import tsx --test backend/test/games.test.ts backend/test/saves.test.ts
+```
+
+Attendu : tous verts une fois la Task 11 faite. Le test du blob de 900 Ko est celui qui compte le plus : c'est la seule vérification que les savestates réels survivent au changement de driver.
+
+- [ ] **Step 5: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/db/games.ts backend/test/games.test.ts
+git commit -m "Give games a repository, and prove a 900KB savestate survives"
+```
+
+### Task 11: Le dépôt des sauvegardes
+
+**Files:**
+- Create: `backend/src/db/saves.ts`
+- Create: `backend/test/saves.test.ts`
+
+**Interfaces:**
+- Consumes: `Database`, `Save`, `Game`
+- Produces:
+  - `interface SaveWithGame extends Save { game: Game }`
+  - `findSaveInSlot(db, gameId, slotNumber, ownerId): Save | null`
+  - `findSaveWithGame(db, id): SaveWithGame | null`
+  - `createSave(db, input: { gameId: string; slotNumber: number; name: string; data: Buffer; screenshot: string | null }): Save`
+  - `updateSaveData(db, id, name: string, data: Buffer): void`
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `backend/test/saves.test.ts` :
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { migratedDb, insertUser } from './helpers.js';
+import { createGame } from '../src/db/games.js';
+import { findSaveInSlot, findSaveWithGame, createSave, updateSaveData } from '../src/db/saves.js';
+
+const NO_METADATA = {
+  genre: null, publisher: null, developer: null, releaseDate: null,
+  players: null, region: null, description: null, coverUrl: null
+};
+
+function aGame(db: ReturnType<typeof migratedDb>, userId: string) {
+  return createGame(db, {
+    title: 'G', filename: 'g.sfc', crc32: 'AAAAAAAA', userId, ...NO_METADATA
+  });
+}
+
+test('createSave stamps id and both timestamps, and keeps the blob', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const game = aGame(db, user.id);
+
+  const save = createSave(db, {
+    gameId: game.id, slotNumber: 1, name: 'first', data: Buffer.from([1, 2, 3]), screenshot: null
+  });
+
+  assert.ok(save.id.length > 0);
+  assert.ok(save.createdAt instanceof Date);
+  assert.ok(save.updatedAt instanceof Date);
+  assert.ok(Buffer.isBuffer(save.data));
+  assert.deepEqual([...save.data], [1, 2, 3]);
+});
+
+test('findSaveInSlot only finds a slot in a game the caller owns', () => {
+  const db = migratedDb();
+  const mine = insertUser(db);
+  const theirs = insertUser(db);
+  const game = aGame(db, mine.id);
+  createSave(db, { gameId: game.id, slotNumber: 3, name: 's', data: Buffer.from([1]), screenshot: null });
+
+  assert.ok(findSaveInSlot(db, game.id, 3, mine.id));
+  assert.equal(findSaveInSlot(db, game.id, 3, theirs.id), null,
+    'a guest in the room must not reach the host slots');
+  assert.equal(findSaveInSlot(db, game.id, 9, mine.id), null);
+});
+
+test('updateSaveData replaces the blob and advances updatedAt', async () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const game = aGame(db, user.id);
+  const save = createSave(db, {
+    gameId: game.id, slotNumber: 1, name: 'first', data: Buffer.from([1]), screenshot: null
+  });
+  await new Promise(r => setTimeout(r, 5));
+
+  updateSaveData(db, save.id, 'renamed', Buffer.from([7, 7, 7]));
+
+  const read = findSaveInSlot(db, game.id, 1, user.id)!;
+  assert.equal(read.name, 'renamed');
+  assert.deepEqual([...read.data], [7, 7, 7]);
+  assert.ok(read.updatedAt.getTime() > save.updatedAt.getTime());
+});
+
+test('findSaveWithGame nests the owning game, so the caller can check ownership', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const game = aGame(db, user.id);
+  const save = createSave(db, {
+    gameId: game.id, slotNumber: 1, name: 's', data: Buffer.from([1]), screenshot: null
+  });
+
+  const found = findSaveWithGame(db, save.id)!;
+
+  assert.equal(found.game.id, game.id);
+  assert.equal(found.game.userId, user.id);
+  assert.ok(found.game.uploadedAt instanceof Date);
+  assert.ok(Buffer.isBuffer(found.data));
+});
+
+test('findSaveWithGame returns null for an unknown save', () => {
+  const db = migratedDb();
+  assert.equal(findSaveWithGame(db, 'nope'), null);
+});
+
+test('one slot per game is enforced by the schema', () => {
+  const db = migratedDb();
+  const user = insertUser(db);
+  const game = aGame(db, user.id);
+  createSave(db, { gameId: game.id, slotNumber: 1, name: 'a', data: Buffer.from([1]), screenshot: null });
+
+  assert.throws(
+    () => createSave(db, { gameId: game.id, slotNumber: 1, name: 'b', data: Buffer.from([2]), screenshot: null }),
+    /UNIQUE/,
+    'the unique index on (gameId, slotNumber) is why the handler checks before inserting'
+  );
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour les voir échouer**
+
+```bash
+node --import tsx --test backend/test/saves.test.ts
+```
+
+Attendu : ÉCHEC — module introuvable.
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Créer `backend/src/db/saves.ts` :
+
+```ts
+import { randomUUID } from 'node:crypto';
+import type { Database } from './sqlite.js';
+import type { Game, Save } from './types.js';
+
+export interface SaveWithGame extends Save {
+  game: Game;
+}
+
+interface SaveRow {
+  id: string;
+  name: string;
+  slotNumber: number;
+  data: Buffer;
+  screenshot: string | null;
+  createdAt: number;
+  updatedAt: number;
+  gameId: string;
+}
+
+function toSave(row: SaveRow): Save {
+  return {
+    id: row.id,
+    name: row.name,
+    slotNumber: row.slotNumber,
+    data: row.data,
+    screenshot: row.screenshot,
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt),
+    gameId: row.gameId
+  };
+}
+
+/**
+ * Finds a slot, but only inside a game the caller owns.
+ *
+ * The ownership test is part of the query rather than a check afterwards: a
+ * guest sitting in someone else room must never reach the host slots, and a
+ * filter that lives in the SQL cannot be forgotten by a caller.
+ */
+export function findSaveInSlot(
+  db: Database, gameId: string, slotNumber: number, ownerId: string
+): Save | null {
+  const row = db.prepare(`
+    SELECT s.* FROM "Save" s
+    JOIN "Game" g ON g.id = s.gameId
+    WHERE s.gameId = ? AND s.slotNumber = ? AND g.userId = ?
+  `).get(gameId, slotNumber, ownerId) as SaveRow | undefined;
+  return row ? toSave(row) : null;
+}
+
+export function findSaveWithGame(db: Database, id: string): SaveWithGame | null {
+  const row = db.prepare(`
+    SELECT s.*,
+      g.id AS g_id, g.title AS g_title, g.filename AS g_filename, g.coverUrl AS g_coverUrl,
+      g.uploadedAt AS g_uploadedAt, g.genre AS g_genre, g.publisher AS g_publisher,
+      g.developer AS g_developer, g.releaseDate AS g_releaseDate, g.players AS g_players,
+      g.region AS g_region, g.description AS g_description, g.crc32 AS g_crc32,
+      g.sram AS g_sram, g.sramUpdatedAt AS g_sramUpdatedAt, g.userId AS g_userId
+    FROM "Save" s
+    JOIN "Game" g ON g.id = s.gameId
+    WHERE s.id = ?
+  `).get(id) as Record<string, unknown> | undefined;
+  if (!row) return null;
+
+  const game: Game = {
+    id: row.g_id as string,
+    title: row.g_title as string,
+    filename: row.g_filename as string,
+    coverUrl: (row.g_coverUrl as string | null) ?? null,
+    uploadedAt: new Date(row.g_uploadedAt as number),
+    genre: (row.g_genre as string | null) ?? null,
+    publisher: (row.g_publisher as string | null) ?? null,
+    developer: (row.g_developer as string | null) ?? null,
+    releaseDate: (row.g_releaseDate as string | null) ?? null,
+    players: (row.g_players as string | null) ?? null,
+    region: (row.g_region as string | null) ?? null,
+    description: (row.g_description as string | null) ?? null,
+    crc32: (row.g_crc32 as string | null) ?? null,
+    sram: (row.g_sram as Buffer | null) ?? null,
+    sramUpdatedAt: row.g_sramUpdatedAt === null ? null : new Date(row.g_sramUpdatedAt as number),
+    userId: row.g_userId as string
+  };
+
+  return {
+    ...toSave({
+      id: row.id as string,
+      name: row.name as string,
+      slotNumber: row.slotNumber as number,
+      data: row.data as Buffer,
+      screenshot: (row.screenshot as string | null) ?? null,
+      createdAt: row.createdAt as number,
+      updatedAt: row.updatedAt as number,
+      gameId: row.gameId as string
+    }),
+    game
+  };
+}
+
+export function createSave(
+  db: Database,
+  input: { gameId: string; slotNumber: number; name: string; data: Buffer; screenshot: string | null }
+): Save {
+  const id = randomUUID();
+  const now = Date.now();
+  db.prepare(`
+    INSERT INTO "Save" (id, name, slotNumber, data, screenshot, createdAt, updatedAt, gameId)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, input.name, input.slotNumber, input.data, input.screenshot, now, now, input.gameId);
+
+  const row = db.prepare(`SELECT * FROM "Save" WHERE id = ?`).get(id) as SaveRow;
+  return toSave(row);
+}
+
+export function updateSaveData(db: Database, id: string, name: string, data: Buffer): void {
+  db.prepare(`UPDATE "Save" SET name = ?, data = ?, updatedAt = ? WHERE id = ?`)
+    .run(name, data, Date.now(), id);
+}
+```
+
+- [ ] **Step 4: Lancer les tests pour les voir passer**
+
+```bash
+node --import tsx --test backend/test/saves.test.ts backend/test/games.test.ts
+```
+
+Attendu : les deux suites vertes.
+
+- [ ] **Step 5: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/db/saves.ts backend/test/saves.test.ts
+git commit -m "Put the save ownership check inside the query"
+```
+
+### Task 12: Le dépôt des métadonnées
+
+**Files:**
+- Create: `backend/src/db/game-metadata.ts`
+- Create: `backend/test/game-metadata.test.ts`
+
+**Interfaces:**
+- Consumes: `Database`, `GameMetadata`
+- Produces:
+  - `countGameMetadata(db): number`
+  - `createGameMetadata(db, entry): void`
+  - `listGameMetadata(db): GameMetadata[]`
+  - `findGameMetadataByChecksum(db, checksum): GameMetadata | null`
+  - `deleteAllGameMetadata(db): void`
+  - `insertGameMetadataBatch(db, entries): number`
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `backend/test/game-metadata.test.ts` :
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { migratedDb } from './helpers.js';
+import {
+  countGameMetadata, createGameMetadata, listGameMetadata,
+  findGameMetadataByChecksum, deleteAllGameMetadata, insertGameMetadataBatch
+} from '../src/db/game-metadata.js';
+
+const ENTRY = {
+  title: 'Super Metroid', altTitle: null, genre: 'Action', publisher: 'Nintendo',
+  developer: 'Nintendo R&D1', releaseDate: '1994-03-19', players: '1',
+  region: 'NTSC', description: 'A game', coverUrl: 'sm.png',
+  crc32: 'D63ED5F8', md5: 'abc123'
+};
+
+test('an empty catalogue counts zero', () => {
+  const db = migratedDb();
+  assert.equal(countGameMetadata(db), 0);
+});
+
+test('a created entry is counted, listed and found by checksum', () => {
+  const db = migratedDb();
+  createGameMetadata(db, ENTRY);
+
+  assert.equal(countGameMetadata(db), 1);
+
+  const [listed] = listGameMetadata(db);
+  assert.equal(listed.title, 'Super Metroid');
+  assert.ok(listed.createdAt instanceof Date);
+
+  assert.equal(findGameMetadataByChecksum(db, 'D63ED5F8')!.title, 'Super Metroid');
+  assert.equal(findGameMetadataByChecksum(db, 'abc123')!.title, 'Super Metroid',
+    'the lookup accepts a CRC32 or an MD5, as it always did');
+  assert.equal(findGameMetadataByChecksum(db, 'nothing'), null);
+});
+
+test('optional fields survive as null rather than undefined', () => {
+  const db = migratedDb();
+  createGameMetadata(db, { ...ENTRY, altTitle: null, coverUrl: null, md5: null });
+
+  const [listed] = listGameMetadata(db);
+  assert.equal(listed.altTitle, null);
+  assert.equal(listed.coverUrl, null);
+  assert.equal(listed.md5, null);
+});
+
+test('the batch insert loads a whole catalogue at once', () => {
+  const db = migratedDb();
+  const entries = Array.from({ length: 200 }, (_, i) => ({
+    ...ENTRY, title: `Game ${i}`, crc32: `CRC${i}`, md5: `MD5${i}`
+  }));
+
+  const inserted = insertGameMetadataBatch(db, entries);
+
+  assert.equal(inserted, 200);
+  assert.equal(countGameMetadata(db), 200);
+});
+
+test('refreshing clears the catalogue', () => {
+  const db = migratedDb();
+  createGameMetadata(db, ENTRY);
+
+  deleteAllGameMetadata(db);
+
+  assert.equal(countGameMetadata(db), 0);
+});
+```
+
+- [ ] **Step 2: Lancer les tests pour les voir échouer**
+
+```bash
+node --import tsx --test backend/test/game-metadata.test.ts
+```
+
+Attendu : ÉCHEC — module introuvable.
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Créer `backend/src/db/game-metadata.ts` :
+
+```ts
+import { randomUUID } from 'node:crypto';
+import type { Database } from './sqlite.js';
+import type { GameMetadata } from './types.js';
+
+export interface GameMetadataInput {
+  title: string;
+  altTitle: string | null;
+  genre: string | null;
+  publisher: string | null;
+  developer: string | null;
+  releaseDate: string | null;
+  players: string | null;
+  region: string | null;
+  description: string | null;
+  coverUrl: string | null;
+  crc32: string | null;
+  md5: string | null;
+}
+
+interface MetadataRow extends Omit<GameMetadata, 'createdAt' | 'updatedAt'> {
+  createdAt: number;
+  updatedAt: number;
+}
+
+function toMetadata(row: MetadataRow): GameMetadata {
+  return {
+    ...row,
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt)
+  };
+}
+
+const INSERT = `
+  INSERT INTO "GameMetadata" (id, title, altTitle, genre, publisher, developer,
+                              releaseDate, players, region, description, coverUrl,
+                              crc32, md5, createdAt, updatedAt)
+  VALUES (@id, @title, @altTitle, @genre, @publisher, @developer,
+          @releaseDate, @players, @region, @description, @coverUrl,
+          @crc32, @md5, @now, @now)
+`;
+
+/** `undefined` binds as an error in better-sqlite3; the JSON catalogue is full of holes. */
+function normalise(entry: GameMetadataInput): GameMetadataInput {
+  return {
+    title: entry.title,
+    altTitle: entry.altTitle ?? null,
+    genre: entry.genre ?? null,
+    publisher: entry.publisher ?? null,
+    developer: entry.developer ?? null,
+    releaseDate: entry.releaseDate ?? null,
+    players: entry.players ?? null,
+    region: entry.region ?? null,
+    description: entry.description ?? null,
+    coverUrl: entry.coverUrl ?? null,
+    crc32: entry.crc32 ?? null,
+    md5: entry.md5 ?? null
+  };
+}
+
+export function countGameMetadata(db: Database): number {
+  const row = db.prepare(`SELECT COUNT(*) AS n FROM "GameMetadata"`).get() as { n: number };
+  return row.n;
+}
+
+export function createGameMetadata(db: Database, entry: GameMetadataInput): void {
+  db.prepare(INSERT).run({ id: randomUUID(), now: Date.now(), ...normalise(entry) });
+}
+
+/**
+ * Loads the whole catalogue in one transaction.
+ *
+ * The old loader inserted several thousand rows one statement at a time, each
+ * its own implicit transaction. One transaction turns that from thousands of
+ * fsyncs into one.
+ */
+export function insertGameMetadataBatch(db: Database, entries: GameMetadataInput[]): number {
+  const statement = db.prepare(INSERT);
+  const now = Date.now();
+  const run = db.transaction((rows: GameMetadataInput[]) => {
+    for (const entry of rows) {
+      statement.run({ id: randomUUID(), now, ...normalise(entry) });
+    }
+    return rows.length;
+  });
+  return run(entries);
+}
+
+export function listGameMetadata(db: Database): GameMetadata[] {
+  const rows = db.prepare(`SELECT * FROM "GameMetadata"`).all() as MetadataRow[];
+  return rows.map(toMetadata);
+}
+
+export function findGameMetadataByChecksum(db: Database, checksum: string): GameMetadata | null {
+  const row = db.prepare(`SELECT * FROM "GameMetadata" WHERE crc32 = ? OR md5 = ?`)
+    .get(checksum, checksum) as MetadataRow | undefined;
+  return row ? toMetadata(row) : null;
+}
+
+export function deleteAllGameMetadata(db: Database): void {
+  db.prepare(`DELETE FROM "GameMetadata"`).run();
+}
+```
+
+- [ ] **Step 4: Lancer les tests pour les voir passer**
+
+```bash
+node --import tsx --test backend/test/game-metadata.test.ts
+```
+
+Attendu : 5 tests passants.
+
+- [ ] **Step 5: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/db/game-metadata.ts backend/test/game-metadata.test.ts
+git commit -m "Load the metadata catalogue in one transaction, not thousands"
+```
+
+### Task 13: Basculer les appelants d'authentification et de profil
+
+**Files:**
+- Modify: `backend/src/auth/passport.ts:3,26,43,52,76`
+- Modify: `backend/src/api/auth.ts:4,66`
+- Modify: `backend/src/api/user.ts:3,17,46,64`
+- Modify: `backend/src/services/user-config.ts:2,18`
+- Modify: `backend/src/websocket/index.ts:3,83`
+- Modify: `backend/src/types/index.ts:1-3`
+
+**Interfaces:**
+- Consumes: tout `backend/src/db/users.ts`, `getDb` de `sqlite.ts`
+- Produces: `User` exporté depuis `backend/src/types/index.ts` sans passer par Prisma
+
+- [ ] **Step 1: Couper le type `User` de Prisma**
+
+Dans `backend/src/types/index.ts`, remplacer les trois premières lignes :
+
+```ts
+import { User as PrismaUser } from '@prisma/client';
+
+export interface User extends PrismaUser {}
+```
+
+par :
+
+```ts
+export type { User } from '../db/types.js';
+```
+
+- [ ] **Step 2: Basculer `passport.ts`**
+
+Remplacer `import { prisma } from '../db/prisma.js';` par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import { findUserByGoogleId, findUserById, createUser, updateUserProfile } from '../db/users.js';
+```
+
+Puis, dans le callback de la stratégie Google, remplacer le bloc `findUnique` / `create` / `update` (lignes 26 à 59) par :
+
+```ts
+            const db = getDb();
+            let user = findUserByGoogleId(db, profile.id);
+
+            // Download avatar from Google if available
+            let avatarUrl = null;
+            const googleAvatarUrl = profile.photos?.[0]?.value;
+            if (googleAvatarUrl) {
+              const downloadedAvatar = await downloadAvatar(googleAvatarUrl, profile.id);
+              avatarUrl = downloadedAvatar || googleAvatarUrl; // Fallback to Google URL if download fails
+            }
+
+            // The OAuth tokens are deliberately not kept. They existed to call
+            // Drive on the player's behalf; with ROMs staying on their machine
+            // there is nothing left to call, and storing a refresh token you
+            // never use is a standing liability for no benefit.
+            if (!user) {
+              user = createUser(db, {
+                googleId: profile.id,
+                email,
+                displayName: profile.displayName,
+                avatar: avatarUrl
+              });
+            } else {
+              user = updateUserProfile(db, user.id, {
+                displayName: profile.displayName,
+                avatar: avatarUrl
+              });
+            }
+```
+
+et dans `deserializeUser`, remplacer :
+
+```ts
+      const user = await prisma.user.findUnique({ where: { id } });
+```
+
+par :
+
+```ts
+      const user = findUserById(getDb(), id);
+```
+
+Les fonctions du dépôt sont synchrones ; les callbacks restent `async` car `downloadAvatar` l'est.
+
+- [ ] **Step 3: Basculer `api/auth.ts`**
+
+Remplacer l'import par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import { upsertDevUser } from '../db/users.js';
+```
+
+et remplacer le bloc `prisma.user.upsert` (lignes 66-70) par :
+
+```ts
+      const user = upsertDevUser(getDb(), userData);
+```
+
+`userData` a déjà exactement la forme attendue : `{ id, email, displayName, googleId, avatar }`.
+
+- [ ] **Step 4: Basculer `api/user.ts`**
+
+Remplacer l'import par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import { findControlsConfig, updateControlsConfig } from '../db/users.js';
+```
+
+Puis les trois sites :
+
+```ts
+    const stored = findControlsConfig(getDb(), userId);
+
+    if (!stored) {
+      // Return default configuration if none saved
+      return res.json(getDefaultKeyConfig());
+    }
+
+    const config = JSON.parse(stored);
+    res.json(config);
+```
+
+```ts
+    updateControlsConfig(getDb(), userId, JSON.stringify(config));
+```
+
+```ts
+    updateControlsConfig(getDb(), userId, JSON.stringify(defaultConfig));
+```
+
+- [ ] **Step 5: Basculer `services/user-config.ts`**
+
+Remplacer l'import par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import { findControlsConfig } from '../db/users.js';
+```
+
+et le corps du `try` :
+
+```ts
+    const stored = findControlsConfig(getDb(), userId);
+
+    if (stored) {
+      const parsedConfig = JSON.parse(stored);
+      cache.set(cacheKey, parsedConfig, 300000); // Cache for 5 minutes
+      return parsedConfig;
+    }
+```
+
+- [ ] **Step 6: Basculer `websocket/index.ts`**
+
+Remplacer l'import par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import { findUserById } from '../db/users.js';
+```
+
+et le chargement de l'utilisateur :
+
+```ts
+  // Load full user data from database (WebSocket doesn't run deserializeUser)
+  const user = findUserById(getDb(), userId);
+```
+
+- [ ] **Step 7: Vérifier que rien ne référence plus Prisma sur ce chemin**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+grep -n "prisma" backend/src/auth/passport.ts backend/src/api/auth.ts backend/src/api/user.ts backend/src/services/user-config.ts backend/src/websocket/index.ts backend/src/types/index.ts
+npx tsc --noEmit -p backend/tsconfig.json
+```
+
+Attendu : aucun résultat du `grep`, et `tsc` sans erreur.
+
+- [ ] **Step 8: Vérifier le comportement réel de la connexion**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+docker compose up -d
+npx playwright test --config e2e/playwright.config.ts
+```
+
+Attendu : la suite passe. Le `global-setup.ts` de Playwright passe par `/auth/dev/login`, donc c'est `upsertDevUser` qui est exercé — le chemin le plus délicat de cette tâche.
+
+- [ ] **Step 9: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/auth/passport.ts backend/src/api/auth.ts backend/src/api/user.ts backend/src/services/user-config.ts backend/src/websocket/index.ts backend/src/types/index.ts
+git commit -m "Read users through the repository, not the ORM"
+```
+
+### Task 14: Basculer les appelants d'amitiés
+
+**Files:**
+- Modify: `backend/src/services/friends.ts:2,10,89`
+- Modify: `backend/src/api/friends.ts:4,20,49,74,96,129,133,147,160,187,195,240,252`
+
+**Interfaces:**
+- Consumes: tout `backend/src/db/friendships.ts`, `findUserById`/`findUserByEmail`/`searchUsers` de `users.ts`
+- Produces: rien de nouveau
+
+- [ ] **Step 1: Basculer `services/friends.ts`**
+
+Remplacer `import { prisma } from '../db/prisma.js';` par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import { listAcceptedFriendshipsFor, listAcceptedFriendshipsWithProfiles } from '../db/friendships.js';
+```
+
+`getFriendships` devient :
+
+```ts
+export async function getFriendships(userId: string) {
+  const cacheKey = `friendships:${userId}`;
+  let friendships = cache.get<any[]>(cacheKey);
+
+  if (!friendships) {
+    friendships = listAcceptedFriendshipsFor(getDb(), userId);
+    cache.set(cacheKey, friendships, 30000); // Cache for 30 seconds
+  }
+
+  return friendships;
+}
+```
+
+`getOnlineFriends` devient :
+
+```ts
+export async function getOnlineFriends(
+  userId: string,
+  presence: { socketFor(userId: string): string | undefined }
+): Promise<any[]> {
+  const friendships = listAcceptedFriendshipsWithProfiles(getDb(), userId);
+
+  return friendships.map(friendship => {
+    const friend = friendship.initiatorId === userId ? friendship.receiver : friendship.initiator;
+    // Narrowed on purpose: the old query selected these four columns, and the
+    // repository hands back the whole User. Spreading it here would put
+    // googleId and the timestamps on the wire.
+    return {
+      id: friend.id,
+      displayName: friend.displayName,
+      avatar: friend.avatar,
+      email: friend.email,
+      online: presence.socketFor(friend.id) !== undefined
+    };
+  });
+}
+```
+
+Ce rétrécissement est le seul endroit de la bascule où un `select:` de Prisma ne se traduit pas par une fonction dédiée. Il est explicite et commenté pour cette raison.
+
+- [ ] **Step 2: Basculer les deux listes de `api/friends.ts`**
+
+Remplacer `import { prisma } from '../db/prisma.js';` par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import {
+  listAcceptedFriendshipsWithProfiles, listPendingRequestsFor, listFriendshipPairsFor,
+  findFriendshipById, findFriendshipBetween, createFriendshipRequest,
+  acceptFriendship, deleteFriendship
+} from '../db/friendships.js';
+import { findUserById, findUserByEmail, searchUsers } from '../db/users.js';
+```
+
+Route `GET /` :
+
+```ts
+  const friendships = listAcceptedFriendshipsWithProfiles(getDb(), user.id);
+```
+
+Route `GET /requests` :
+
+```ts
+  const requests = listPendingRequestsFor(getDb(), user.id);
+```
+
+- [ ] **Step 3: Basculer la recherche**
+
+Route `GET /search`, remplacer les deux requêtes (lignes 74-108) par :
+
+```ts
+  const db = getDb();
+  const users = searchUsers(db, user.id, searchQuery, 10);
+  const friendships = listFriendshipPairsFor(db, user.id);
+```
+
+Le reste de la route — la construction de `friendIds` et le filtre — ne change pas.
+
+- [ ] **Step 4: Basculer l'envoi de demande**
+
+Route `POST /request` :
+
+```ts
+  const db = getDb();
+  let friend;
+
+  // Search by ID first if provided, otherwise by email
+  if (friendId) {
+    friend = findUserById(db, friendId);
+  } else if (friendEmail) {
+    friend = findUserByEmail(db, friendEmail);
+  }
+```
+
+puis :
+
+```ts
+  const existing = findFriendshipBetween(db, user.id, friend.id);
+```
+
+et :
+
+```ts
+  const friendship = createFriendshipRequest(db, user.id, friend.id);
+```
+
+`findFriendshipBetween` remplace le `findFirst` à deux branches `OR` : la fonction du dépôt teste déjà les deux sens.
+
+- [ ] **Step 5: Basculer l'acceptation et la suppression**
+
+Route `POST /accept/:friendshipId` :
+
+```ts
+  const db = getDb();
+  const friendship = findFriendshipById(db, friendshipId);
+
+  if (!friendship || friendship.receiverId !== user.id) {
+    return res.status(404).json({ error: 'Friend request not found' });
+  }
+
+  const updated = acceptFriendship(db, friendshipId);
+```
+
+Route `DELETE /:friendshipId` :
+
+```ts
+  const db = getDb();
+  const friendship = findFriendshipById(db, friendshipId);
+```
+
+puis :
+
+```ts
+  deleteFriendship(db, friendshipId);
+```
+
+- [ ] **Step 6: Vérifier**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+grep -n "prisma" backend/src/services/friends.ts backend/src/api/friends.ts
+npx tsc --noEmit -p backend/tsconfig.json
+npx playwright test --config e2e/playwright.config.ts
+```
+
+Attendu : aucun `prisma`, `tsc` propre, suite Playwright verte.
+
+- [ ] **Step 7: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/services/friends.ts backend/src/api/friends.ts
+git commit -m "Read friendships through the repository, keeping the wire shape"
+```
+
+### Task 15: Basculer les appelants de jeux, sauvegardes et métadonnées
+
+**Files:**
+- Modify: `backend/src/api/games.ts:4,29,67,74,82,120,124,131,140,154,166,187,198`
+- Modify: `backend/src/websocket/game-handlers.ts:3,113,123,138,147,172,226,251`
+- Modify: `backend/src/websocket/room-handlers.ts:11,29`
+- Modify: `backend/src/services/metadata-loader.ts:4,46,59,85,147,185,204`
+
+**Interfaces:**
+- Consumes: tout `games.ts`, `saves.ts`, `game-metadata.ts`
+- Produces: rien de nouveau — c'est le dernier appelant
+
+- [ ] **Step 1: Basculer `api/games.ts`**
+
+Remplacer l'import par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import {
+  listGamesWithSaveSummaries, listGamesFor, findGameById, findGameWithSaves,
+  findGameByChecksum, findOtherGameWithChecksum, countGamesFor, createGame,
+  updateGameChecksum, updateGameMetadata, deleteGame
+} from '../db/games.js';
+```
+
+Les sites, dans l'ordre :
+
+```ts
+  const games = listGamesWithSaveSummaries(getDb(), user.id);
+```
+
+```ts
+  const db = getDb();
+  const existing = findGameByChecksum(db, user.id, checksum);
+```
+
+```ts
+  const count = countGamesFor(db, user.id);
+```
+
+```ts
+  const game = createGame(db, {
+    title: metadata?.title || detected,
+    filename,
+    crc32: checksum,
+    userId: user.id,
+    genre: metadata?.genre ?? null,
+    publisher: metadata?.publisher ?? null,
+    developer: metadata?.developer ?? null,
+    releaseDate: metadata?.releaseDate ?? null,
+    players: metadata?.players ?? null,
+    region: metadata?.region ?? null,
+    description: metadata?.description ?? null,
+    coverUrl: metadata?.coverUrl ?? null
+  });
+```
+
+Le spread conditionnel `...(metadata && { ... })` disparaît : `createGame` attend les neuf champs, chacun explicitement `null` en l'absence de métadonnées. C'est plus verbeux et cela supprime une classe de bug — un champ oublié dans le spread laissait la colonne à sa valeur par défaut sans que rien ne le signale.
+
+```ts
+  const db = getDb();
+  const game = findGameById(db, req.params.gameId);
+```
+
+```ts
+  const clash = findOtherGameWithChecksum(db, user.id, checksum, game.id);
+```
+
+```ts
+  const updated = updateGameChecksum(db, game.id, checksum);
+```
+
+```ts
+  const db = getDb();
+  const game = findGameById(db, gameId);
+```
+
+```ts
+  deleteGame(db, gameId);
+```
+
+```ts
+  const game = findGameWithSaves(getDb(), gameId);
+```
+
+```ts
+    const db = getDb();
+    const games = listGamesFor(db, user.id);
+```
+
+```ts
+        updateGameMetadata(db, game.id, {
+          title: metadata.title,
+          genre: metadata.genre ?? null,
+          publisher: metadata.publisher ?? null,
+          developer: metadata.developer ?? null,
+          releaseDate: metadata.releaseDate ?? null,
+          players: metadata.players ?? null,
+          region: metadata.region ?? null,
+          description: metadata.description ?? null,
+          coverUrl: metadata.coverUrl ?? null
+        });
+```
+
+- [ ] **Step 2: Basculer `websocket/game-handlers.ts`**
+
+Remplacer l'import par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import { findOwnedGameId, saveSram, findSram } from '../db/games.js';
+import { findSaveInSlot, findSaveWithGame, createSave, updateSaveData } from '../db/saves.js';
+```
+
+Bloc `game:save` :
+
+```ts
+      const db = getDb();
+      // Saves belong to the game's owner. Without this check a guest in the
+      // room would create Save rows against the host's game (mirrors the
+      // ownership check in game:load).
+      const ownedGameId = findOwnedGameId(db, room.gameId, userId);
+
+      if (!ownedGameId) {
+        socket.emit('error', { message: 'Not authorized to save this game' });
+        return;
+      }
+
+      const existingSave = findSaveInSlot(db, room.gameId, data.slotNumber, userId);
+
+      const saveDataBuffer = data.saveData
+        ? Buffer.from(data.saveData, 'base64')
+        : Buffer.alloc(0);
+
+      if (existingSave) {
+        updateSaveData(db, existingSave.id, data.name, saveDataBuffer);
+      } else {
+        createSave(db, {
+          gameId: room.gameId,
+          slotNumber: data.slotNumber,
+          name: data.name,
+          data: saveDataBuffer,
+          screenshot: null
+        });
+      }
+```
+
+Bloc `game:load` :
+
+```ts
+      const save = findSaveWithGame(getDb(), data.saveId);
+```
+
+Le reste du bloc ne change pas : `save.game.userId`, `save.data.toString('base64')`, `save.slotNumber` et `save.name` gardent leur forme.
+
+Bloc `game:saveSram` :
+
+```ts
+      saveSram(getDb(), room.gameId, userId, sramBuffer);
+```
+
+Bloc `game:loadSram` :
+
+```ts
+      const stored = findSram(getDb(), room.gameId, userId);
+
+      if (!stored) {
+        socket.emit('game:sramLoaded', { sramData: null });
+        return;
+      }
+
+      const sramDataBase64 = stored.sram.toString('base64');
+      socket.emit('game:sramLoaded', {
+        sramData: sramDataBase64,
+        updatedAt: stored.sramUpdatedAt
+      });
+      logger.info({ gameId: room.gameId, size: stored.sram.length }, 'SRAM loaded');
+```
+
+`findSram` renvoie déjà `null` quand la colonne est vide, ce que la double condition `!game || !game.sram` faisait à la main.
+
+- [ ] **Step 3: Basculer `websocket/room-handlers.ts`**
+
+Remplacer `import { prisma } from '../db/prisma.js';` par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import { findChecksumOfOwnedGame } from '../db/games.js';
+```
+
+et le site :
+
+```ts
+    // Read from the host's library rather than trusting the payload: the guest
+    // will use this checksum to pick a file off their own disk, so it has to
+    // be the one the server recorded.
+    const gameCrc32 = findChecksumOfOwnedGame(getDb(), data.gameId, user.id);
+```
+
+puis, dans la construction de la salle, remplacer `gameCrc32: game?.crc32 ?? undefined,` par :
+
+```ts
+      gameCrc32: gameCrc32 ?? undefined,
+```
+
+- [ ] **Step 4: Basculer `services/metadata-loader.ts`**
+
+Remplacer l'import par :
+
+```ts
+import { getDb } from '../db/sqlite.js';
+import {
+  countGameMetadata, insertGameMetadataBatch, listGameMetadata,
+  findGameMetadataByChecksum as findMetadataRowByChecksum, deleteAllGameMetadata
+} from '../db/game-metadata.js';
+```
+
+L'alias évite une collision : ce fichier exporte déjà une fonction `findGameMetadataByChecksum`.
+
+Le chargement initial, qui insérait entrée par entrée, devient :
+
+```ts
+    const db = getDb();
+    const existingCount = countGameMetadata(db);
+
+    if (existingCount > 0) {
+      logger.info({ count: existingCount }, 'Metadata already loaded, skipping');
+      return;
+    }
+
+    const successCount = insertGameMetadataBatch(db, metadata.map(entry => ({
+      title: entry.title,
+      altTitle: entry.altTitle ?? null,
+      genre: entry.genre ?? null,
+      publisher: entry.publisher ?? null,
+      developer: entry.developer ?? null,
+      releaseDate: entry.releaseDate ?? null,
+      players: entry.players ?? null,
+      region: entry.region ?? null,
+      description: entry.description ?? null,
+      coverUrl: entry.coverUrl ?? null,
+      crc32: entry.crc32 ?? null,
+      md5: entry.md5 ?? null
+    })));
+
+    logger.info({ successCount }, 'Metadata loaded successfully');
+
+    // Load metadata into cache
+    metadataCache = listGameMetadata(db);
+    logger.info({ count: metadataCache.length }, 'Cached metadata entries in memory');
+```
+
+**Changement de comportement à signaler.** La boucle actuelle attrape l'erreur par entrée et compte les échecs (`errorCount`) ; l'insertion par lot est transactionnelle, donc une entrée invalide fait échouer le lot entier. C'est un compromis à assumer explicitement : le catalogue est un fichier livré avec l'image, pas une entrée utilisateur, et un lot qui échoue est un signal plus honnête qu'un compteur d'erreurs que personne ne lit. Le `try/catch` externe existant continue de laisser l'application démarrer sans métadonnées.
+
+Les deux autres sites :
+
+```ts
+    metadataCache = listGameMetadata(getDb());
+```
+
+```ts
+export async function findGameMetadataByChecksum(checksum: string): Promise<any | null> {
+  return findMetadataRowByChecksum(getDb(), checksum);
+}
+```
+
+```ts
+  deleteAllGameMetadata(getDb());
+```
+
+- [ ] **Step 5: Vérifier qu'aucun appelant ne référence plus Prisma**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+grep -rn "prisma" backend/src --include='*.ts'
+```
+
+Attendu : uniquement `backend/src/db/prisma.ts` (supprimé à la Task 16) et le commentaire de `backend/src/db/redis.ts:5`, à reformuler.
+
+```bash
+npx tsc --noEmit -p backend/tsconfig.json
+npm run test:backend
+npx playwright test --config e2e/playwright.config.ts
+```
+
+Attendu : `tsc` propre, suites backend vertes, Playwright vert. `local-roms.spec.ts` et `rom-transfer.spec.ts` exercent le chemin des jeux et des sauvegardes.
+
+- [ ] **Step 6: Commit (demander l'accord d'abord)**
+
+```bash
+git add backend/src/api/games.ts backend/src/websocket/game-handlers.ts backend/src/websocket/room-handlers.ts backend/src/services/metadata-loader.ts
+git commit -m "Read games, saves and metadata through the repositories"
+```
+
+### Task 16: Retirer Prisma
+
+**Files:**
+- Delete: `backend/src/db/prisma.ts`
+- Delete: `backend/prisma/schema.prisma`, `backend/prisma/migrations/`, `backend/prisma/data/`, `backend/prisma/test.db`
+- Delete: `backend/test.db`
+- Modify: `backend/package.json`
+- Modify: `backend/Dockerfile`, `backend/dev.Dockerfile`
+- Modify: `docker-compose.yml:47`
+- Modify: `backend/src/db/redis.ts:5`
+- Modify: `backend/src/index.ts` (appel du runner au démarrage — à confirmer, voir Step 4)
+
+**Interfaces:**
+- Consumes: rien
+- Produces: rien
+
+- [ ] **Step 1: Vérifier qu'il ne reste aucun appelant**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+grep -rn "@prisma/client\|from '../db/prisma\|from './prisma" backend/src --include='*.ts'
+```
+
+Attendu : uniquement `backend/src/db/prisma.ts` lui-même. Toute autre ligne signifie qu'une tâche précédente est incomplète — **ne pas continuer**.
+
+- [ ] **Step 2: Supprimer les fichiers**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+git rm backend/src/db/prisma.ts
+git rm -r backend/prisma
+git rm --cached backend/test.db 2>/dev/null || true
+rm -f backend/test.db
+```
+
+`backend/prisma/data/dev.db` est la base locale vide de décembre 2025, sans `_prisma_migrations` — elle ne contient aucune donnée à sauver. `backend/test.db` appartient à root et date de novembre 2025 ; il peut résister à `rm` sans `sudo`, auquel cas le laisser et l'ajouter au `.gitignore`.
+
+- [ ] **Step 3: Retirer les dépendances et les scripts**
+
+Dans `backend/package.json`, supprimer de `dependencies` :
+
+```json
+    "@prisma/client": "^5.22.0",
+```
+
+de `devDependencies` :
+
+```json
+    "prisma": "^5.22.0",
+```
+
+et de `scripts` :
+
+```json
+    "db:generate": "prisma generate",
+    "db:migrate": "prisma migrate dev"
+```
+
+en ajoutant à la place :
+
+```json
+    "db:migrate": "node --import tsx src/db/migrate-cli.ts"
+```
+
+Puis :
+
+```bash
+bun install
+du -sh node_modules
+```
+
+Attendu : la taille perd environ 86 MB. Consigner la valeur.
+
+- [ ] **Step 4: Appliquer les migrations au démarrage en développement**
+
+Le service `db-migration` de `docker-compose.yml` applique les migrations, mais il `depends_on: backend` — le backend démarre donc avant que les migrations ne soient passées. Cela fonctionnait avec Prisma parce que le client se contentait d'échouer puis de réessayer à la requête suivante.
+
+Vérifier le comportement réel :
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+docker compose down -v
+docker compose up
+```
+
+Si le backend échoue au démarrage sur une base vide, corriger `docker-compose.yml` en inversant la dépendance, comme `docker-compose.prod.yml` le fait déjà :
+
+```yaml
+  backend:
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+      redis:
+        condition: service_started
+```
+
+et retirer `depends_on: - backend` du service `db-migration`.
+
+- [ ] **Step 5: Retirer `prisma generate` des Dockerfiles et de compose**
+
+Dans `backend/dev.Dockerfile`, supprimer :
+
+```dockerfile
+COPY backend/prisma ./prisma
+RUN npx prisma generate
+```
+
+Dans `backend/Dockerfile`, étape `builder`, supprimer :
+
+```dockerfile
+# Copy source code and prisma schema
+COPY backend/prisma ./prisma
+
+# Generate Prisma client
+RUN npx prisma generate
+```
+
+Dans `docker-compose.yml`, service `backend` :
+
+```yaml
+    command: sh -c "bun install && npm run dev"
+```
+
+- [ ] **Step 6: Reformuler le commentaire de `redis.ts`**
+
+`backend/src/db/redis.ts:5` dit « The one Redis connection, mirroring db/prisma.ts. ». Le fichier cité n'existe plus :
+
+```ts
+ * The one Redis connection, mirroring db/sqlite.ts.
+```
+
+- [ ] **Step 7: Vérifier de bout en bout**
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+npx tsc --noEmit -p backend/tsconfig.json
+npm run test:all
+docker compose -f docker-compose.prod.yml build
+docker compose down -v && docker compose up -d
+npx playwright test --config e2e/playwright.config.ts
+```
+
+Attendu : tout vert, et `grep -rn "prisma" backend/ --include='*.ts' --include='*.json' --include='Dockerfile*'` ne renvoie plus rien.
+
+- [ ] **Step 8: Vérifier la bascule sur une base qui vient de Prisma**
+
+C'est le scénario de production, et il n'a encore été testé que par le runner isolé. Reconstruire une base avec Prisma depuis la révision qui précède sa suppression, puis la donner au nouveau runner :
+
+```bash
+cd /home/pleymor/projects/psnes-repos/psnes
+rm -f /tmp/psnes-handover.db
+git worktree add /tmp/psnes-pre-removal HEAD
+(cd /tmp/psnes-pre-removal/backend && npm install && DATABASE_URL="file:/tmp/psnes-handover.db" npx prisma migrate deploy)
+DATABASE_URL="file:/tmp/psnes-handover.db" node --import tsx backend/src/db/migrate-cli.ts
+git worktree remove --force /tmp/psnes-pre-removal
+```
+
+`HEAD` désigne ici le dernier commit **avant** celui de cette tâche : les Steps 1 à 7 ne sont pas encore commités, donc la copie de travail du worktree contient encore `backend/prisma/`.
+
+Attendu : `baselined 0001_baseline.sql (schema already present and matching)`, sortie 0. C'est la preuve que le déploiement en production ne réappliquera rien et ne refusera rien à tort.
+
+- [ ] **Step 9: Relever la mesure finale**
+
+```bash
+du -sh node_modules
+grep -c '"node_modules/' package-lock.json 2>/dev/null || echo "lockfile npm retiré"
+```
+
+Comparer aux 257 MB / 461 paquets du point de départ. C'est la preuve que les trois issues demandaient.
+
+- [ ] **Step 10: Commit (demander l'accord d'abord)**
+
+```bash
+git add -A
+git commit -m "Remove Prisma, 86MB of it, now that nothing calls it"
+```
+
+---
+
+## Ce que ce plan ne fait pas
+
+- Il ne migre pas le runtime vers Bun (#10 Partie 2). À rouvrir une fois la phase 3 livrée.
+- Il ne touche pas à `simple-peer`, aux polyfills, ni aux modes Dual et Streaming.
+- Il ne modifie pas le schéma de la base : la baseline décrit l'existant à l'identique.
+- Il ne supprime pas `_prisma_migrations`, laissée inerte comme trace consultable.

--- a/docs/superpowers/specs/2026-08-18-deps-bun-sqlite-design.md
+++ b/docs/superpowers/specs/2026-08-18-deps-bun-sqlite-design.md
@@ -46,10 +46,14 @@ Quatre étapes, du risque nul au risque réel. Chacune est indépendamment livra
 Retirer ce qui n'a aucun consommateur, vérifié par recherche dans `backend/src`, `frontend/src` et `core` :
 
 - `@sveltejs/adapter-auto`, `@sveltejs/adapter-node` — `frontend/svelte.config.js:1` utilise `adapter-static`
-- `stream-browserify`, `events`, `util` — déclarés et aliasés dans `frontend/vite.config.ts:11-17`, jamais importés
+- `stream-browserify`, `util` — déclarés et aliasés dans `frontend/vite.config.ts:11-17`, jamais importés
 - les entrées correspondantes dans `resolve.alias` et `optimizeDeps.include` de `vite.config.ts`
 
-**Ce qui reste en place.** `simple-peer` porte `frontend/src/lib/webrtc/p2p-manager.ts` (778 lignes), lui-même requis par `dual-mode.ts`, `streaming-mode.ts` et `network-detector.ts`, tous encore câblés depuis `P2PRoom.svelte:1101`. `buffer`, `process` et `path-browserify` le servent via `frontend/src/lib/polyfills.ts`. Les supprimer reviendrait à supprimer les modes Dual et Streaming — une décision produit, qui mérite son issue et non l'effet de bord d'un nettoyage de dépendances.
+**Correction : `events` reste, contrairement à ce que cette spec disait d'abord.** « Aucun importeur dans `src` » ne veut pas dire « aucun importeur ». `simple-peer` tire `readable-stream`, dont le champ `browser` neutralise `util` (`"util": false`) et redirige `stream`, mais ne prévoit rien pour `events` : son `stream-browser.js` fait `require('events').EventEmitter` sans repli. Sans le paquet ni son alias, Vite externalise cet import vers un stub vide **sans faire échouer le build** — `EventEmitter` devient `undefined` dans le bundle, et le WebRTC casse à l'exécution. Le retrait a été tenté, l'inspection du bundle l'a montré, `events` a été remis seul.
+
+La leçon vaut au-delà de ce paquet : une recherche d'imports dans `src` ne prouve rien pour les polyfills, dont l'unique consommateur est toujours une dépendance transitive. Les trois autres ont été retirés sur la même preuve — bundle construit, suite Playwright passante — et non sur le seul `grep`.
+
+**Ce qui reste en place.** `simple-peer` porte `frontend/src/lib/webrtc/p2p-manager.ts` (778 lignes), lui-même requis par `dual-mode.ts`, `streaming-mode.ts` et `network-detector.ts`, tous encore câblés depuis `P2PRoom.svelte:1101`. `buffer`, `process`, `path-browserify` et donc `events` le servent. Les supprimer reviendrait à supprimer les modes Dual et Streaming — une décision produit, qui mérite son issue et non l'effet de bord d'un nettoyage de dépendances.
 
 **Vérification.** `npm run build` du frontend, et `du -sh node_modules` avant/après.
 

--- a/docs/superpowers/specs/2026-08-18-deps-bun-sqlite-design.md
+++ b/docs/superpowers/specs/2026-08-18-deps-bun-sqlite-design.md
@@ -1,0 +1,186 @@
+# Alléger les dépendances, passer à Bun, sortir de Prisma
+
+Conception pour les issues #10, #11 et #13.
+
+## Ce que le repo dit aujourd'hui
+
+Les chiffres des issues ont vieilli. Mesures du 18 août 2026, sur `main` à `9571cec` :
+
+| | Issue | Réel |
+|---|---|---|
+| Packages | 638 | **461** (`package-lock.json`) |
+| `node_modules` | 468 MB | **257 MB** |
+| `googleapis` | 116 MB | **absent** — parti avec #12 |
+| `adm-zip` | à supprimer | **absent** — parti avec #12 |
+| Prisma | 86 MB | **86 MB**, soit un tiers du total |
+| Migrations enregistrées | six | **huit** |
+| Modèles | six | **cinq** — `User`, `Friendship`, `Game`, `Save`, `GameMetadata` |
+
+#12 a donc déjà emporté la moitié de #11. Prisma est aujourd'hui, et de loin, le poste le plus lourd : `node_modules/prisma` (42 MB) et `node_modules/@prisma` (44 MB) devant TypeScript (23 MB) et playwright-core (14 MB).
+
+## Ce que le sondage a établi
+
+Les deux pièges que #13 signalait comme incertains ont été mesurés contre une base reconstruite à partir des huit fichiers de migration.
+
+**Dates.** Les colonnes sont déclarées `DATETIME`, mais SQLite n'a pas ce type et Prisma y écrit un **entier, millisecondes depuis epoch** — vérifié par `typeof(createdAt)` sur une ligne écrite par le client Prisma lui-même. Ce n'est donc pas « des chaînes ou des entiers selon la colonne » : c'est une règle unique. Un driver brut rend un `number` ; la conversion est `new Date(n)` en lecture et `.getTime()` en écriture, sans exception.
+
+**Blobs.** `typeof(data)` vaut `blob`, et Prisma rend un `Buffer`. `better-sqlite3` rend également un `Buffer` et accepte un `Buffer` en liaison : sur ce point, **aucun appelant ne change**. `node:sqlite` et `bun:sqlite` rendraient un `Uint8Array` — c'est une raison de plus de choisir `better-sqlite3`, au-delà de sa portabilité Node/Bun.
+
+Constat annexe, sans rapport avec la conception mais révélateur : le client Prisma généré dans `node_modules` était périmé, il connaissait encore la colonne `googleAccessToken` supprimée par la dernière migration. Un `prisma generate` l'a corrigé. C'est une classe entière de dérive qui disparaît avec l'issue.
+
+## L'état des tests, qui contraint tout le reste
+
+**Le backend n'a aucun test unitaire.** `find backend -name '*.test.ts'` ne renvoie rien. La couverture existante est ailleurs :
+
+- `core/test/` — 12 suites, sur le netplay et le lockstep côté frontend
+- `e2e/` — Playwright, dont `room-authz.spec.ts` et `local-roms.spec.ts` traversent les chemins de données
+
+Réécrire 50 appels de base de données sur 11 fichiers sans filet n'est pas envisageable. Les modules de dépôt de l'étape 3 sont donc écrits en TDD, contre un fichier SQLite temporaire — ce que `better-sqlite3` rend trivial : synchrone, adossé à un fichier, aucun serveur à lancer. Ces tests sont le premier livrable de l'étape 3, pas le dernier.
+
+## Séquence
+
+Quatre étapes, du risque nul au risque réel. Chacune est indépendamment livrable et réversible.
+
+### Étape 1 — Reliquat de #11
+
+Retirer ce qui n'a aucun consommateur, vérifié par recherche dans `backend/src`, `frontend/src` et `core` :
+
+- `@sveltejs/adapter-auto`, `@sveltejs/adapter-node` — `frontend/svelte.config.js:1` utilise `adapter-static`
+- `stream-browserify`, `events`, `util` — déclarés et aliasés dans `frontend/vite.config.ts:11-17`, jamais importés
+- les entrées correspondantes dans `resolve.alias` et `optimizeDeps.include` de `vite.config.ts`
+
+**Ce qui reste en place.** `simple-peer` porte `frontend/src/lib/webrtc/p2p-manager.ts` (778 lignes), lui-même requis par `dual-mode.ts`, `streaming-mode.ts` et `network-detector.ts`, tous encore câblés depuis `P2PRoom.svelte:1101`. `buffer`, `process` et `path-browserify` le servent via `frontend/src/lib/polyfills.ts`. Les supprimer reviendrait à supprimer les modes Dual et Streaming — une décision produit, qui mérite son issue et non l'effet de bord d'un nettoyage de dépendances.
+
+**Vérification.** `npm run build` du frontend, et `du -sh node_modules` avant/après.
+
+### Étape 2 — #10 Partie 1, Bun comme package manager
+
+Node reste le runtime. Bun n'installe que.
+
+| Fichier | Changement |
+|---|---|
+| `backend/Dockerfile` | `npm ci --omit=dev --prefer-offline` → `bun install --production --frozen-lockfile` ; `npm ci --prefer-offline` → `bun install --frozen-lockfile` ; `npm run build` → `bun run build` |
+| `backend/dev.Dockerfile` | `npm install` → `bun install` |
+| `frontend/Dockerfile` | `npm install` → `bun install` ; `npm run build` → `bun run build` |
+| `docker-compose.yml:47` | `sh -c "npm install && npx prisma generate && npm run dev"` → équivalent Bun |
+| `docker-compose.yml:64` | `sh -c "npm install && npm run dev -- --host"` → équivalent Bun |
+| `package.json` | workspaces npm → workspaces Bun |
+
+C'est le `npm install` à chaque démarrage de conteneur, sur 461 packages, qui est visé — la lenteur quotidienne que décrit #10.
+
+**Ce qui ne bouge pas à cette étape.** Les scripts de test restent sur `node --import tsx --test`. Le piège que décrit #10 — porter les suites netplay vers `bun test`, dont les API d'assertion et de mock diffèrent — ne concerne que la Partie 2. Tant que Node exécute, `tsx` reste nécessaire et les 12 suites tournent inchangées. C'est précisément ce que la séparation en deux parties achète.
+
+Les images Node des Dockerfiles gagnent Bun par copie du binaire depuis l'image officielle — `COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun` — plutôt que par un script d'installation. L'image de base reste `node:20`, puisque Node exécute toujours ; la copie est une couche unique et déterministe, qui ne casse pas le cache à chaque build comme le ferait un `curl | bash`.
+
+**Vérification.** `docker compose up --build` démarre ; les 12 suites `core/test` passent ; la suite Playwright passe.
+
+**Retour arrière.** Rétablir les lignes `npm` et supprimer `bun.lockb`. `package-lock.json` reste au dépôt jusqu'à ce que l'étape soit jugée stable.
+
+### Étape 3 — #13, Prisma → `better-sqlite3`
+
+Le gros morceau. 86 MB, 50 opérations de modèle, 11 fichiers.
+
+#### Forme : des modules de dépôt par modèle
+
+Cinq nouveaux fichiers sous `backend/src/db/`, un par modèle : `users.ts`, `games.ts`, `friendships.ts`, `saves.ts`, `game-metadata.ts`. Chacun exporte des fonctions nommées, pas un objet générique :
+
+```ts
+// backend/src/db/friendships.ts
+export function listPendingRequestsFor(userId: string): PendingRequest[] {
+  return stmt.pending.all(userId).map(toPendingRequest);
+}
+```
+
+Les appelants perdent la mécanique et gardent leur forme :
+
+```ts
+// backend/src/api/friends.ts
+- const rows = await prisma.friendship.findMany({
+-   where: { receiverId: userId, status: 'pending' },
+-   include: { initiator: true },
+- });
++ const rows = listPendingRequestsFor(userId);
+
+  rows.map(f => f.initiator.displayName)   // inchangé
+```
+
+Trois propriétés de cette forme comptent :
+
+**Les huit jointures ne se propagent pas.** Les clauses `include:` de `services/friends.ts:97`, `api/friends.ts:28,54,166,198`, `websocket/game-handlers.ts:174` et `api/games.ts:31,168` rendent aujourd'hui des objets imbriqués que les appelants déstructurent — `f.initiator.displayName`, `save.game.userId`, `game.saves`. Chaque jointure devient une fonction qui rend déjà cette forme imbriquée, assemblée dans le module de dépôt. C'est le gros du travail, comme le disait #13, mais il est confiné à cinq fichiers au lieu d'être étalé sur onze.
+
+**Le driver est enfermé.** Aucun `import` de `better-sqlite3` en dehors de `backend/src/db/`. C'est ce qui permettra à l'étape 4 de basculer sur `bun:sqlite` en touchant cinq fichiers — la seule différence sensible étant `Buffer` contre `Uint8Array`, qui sera alors localisée dans les fonctions de conversion.
+
+**Les dates ont un seul point de passage.** Chaque module expose des convertisseurs `toUser`, `toGame`, `toSave` qui transforment la ligne brute en objet typé. Le `new Date(n)` y vit, une fois par modèle, au lieu d'être dispersé sur 50 sites.
+
+#### Types
+
+La surface est plus petite que ne le dit #13. Deux fichiers seulement importent `@prisma/client` : `backend/src/db/prisma.ts:1` pour le client, et `backend/src/types/index.ts:1`, qui importe `User` et le ré-exporte sous forme d'interface. L'issue mentionne aussi `rom-source.ts` et `presence.ts` : le premier n'existe plus, et le second ne référence Prisma nulle part — cette partie de #13 est périmée.
+
+Le type `User` devient donc une interface écrite à la main dans `backend/src/db/types.ts`, aux côtés de `Game`, `Save`, `Friendship` et `GameMetadata`, dérivées du schéma actuel.
+
+Autre confirmation du sondage : aucune occurrence de `prisma.$queryRaw`, `prisma.$executeRaw` ni `prisma.$transaction` dans `backend/src`. Le diagnostic de #13 — pas de transactions, pas d'agrégats — tient.
+
+#### Deux pièges que #13 ne mentionne pas
+
+La lecture des 50 sites en a révélé deux autres, tous deux silencieux — c'est ce qui les rend dangereux : rien n'échoue, les valeurs sont simplement fausses ou les lignes simplement orphelines.
+
+**Prisma remplissait trois colonnes que personne n'écrivait.** `@default(uuid())` fabriquait les `id`, `@default(now())` les `createdAt`, et surtout `@updatedAt` avançait les `updatedAt` à chaque écriture. Aucun appelant ne les mentionne, et aucun ne s'en apercevra s'ils cessent d'être remplis. Or `updatedAt` est visible : `api/friends.ts:38` l'envoie au client comme date d'amitié (`friendsSince`). Chaque `INSERT` fournit donc les trois valeurs, et chaque `UPDATE` sur une table qui porte `updatedAt` la fournit aussi. Les tests de dépôt vérifient explicitement que la date avance.
+
+**SQLite désactive les clés étrangères par défaut.** Le schéma déclare `onDelete: Cascade` sur `Game → Save`, `User → Game` et `User → Friendship`, et `api/games.ts:154` supprime un jeu en comptant dessus pour emporter ses sauvegardes. Prisma activait le pragma ; un driver brut ne le fait pas spontanément. `PRAGMA foreign_keys = ON` est donc appliqué à chaque ouverture de connexion, et testé — supprimer un parent doit laisser zéro enfant.
+
+#### Où vivent les migrations
+
+`backend/migrations/`, et non `backend/src/db/migrations/` : `tsc` ne copie pas les fichiers `.sql` vers `dist/`, donc des migrations placées sous `src/` seraient absentes de l'image de production. Le Dockerfile copie ce répertoire explicitement, comme il copiait `backend/prisma`.
+
+#### Runner de migrations
+
+C'est la partie où #7 peut se rejouer, et elle est traitée comme telle.
+
+- Répertoire `backend/migrations/`, un fichier `0001_baseline.sql` contenant le schéma d'aujourd'hui, puis `0002_…` pour la suite.
+- Table `schema_migrations(name TEXT PRIMARY KEY, applied_at INTEGER)`, propre au runner.
+- Au démarrage sur une base **vide** : la baseline s'exécute, puis les suivantes.
+- Au démarrage sur une base **existante** : le runner compare le `sqlite_master` vivant à celui qu'une baseline fraîche produit. **Identiques** → il enregistre `0001_baseline` sans l'exécuter, puis applique les migrations postérieures. **Différents** → il refuse de démarrer et affiche la différence.
+
+Ce refus est le cœur de la conception, pas un raffinement. Le reproche de #7 à `prisma db push` n'était pas qu'il appliquait le schéma, c'est que personne ne vérifiait que la base réelle correspondait aux fichiers — une dérive pouvait être gelée sans que quiconque la voie. Un runner qui estampille aveuglément reproduirait exactement ce trou.
+
+Les huit `migration.sql` de Prisma ne sont pas portés. Ils contiennent la chorégraphie de reconstruction de tables de Prisma (`PRAGMA defer_foreign_keys`, table `new_Game`, copie, `DROP`, `RENAME`) et sur toute base existante ils ne se rejoueront jamais. Leur histoire reste lisible dans git, où elle a toujours été.
+
+`_prisma_migrations` n'est pas lue et pas supprimée : elle devient inerte. La laisser en place coûte quelques kilo-octets et garde une trace consultable si un doute survient sur ce qui a été appliqué avant la bascule.
+
+#### Ce qui disparaît
+
+`@prisma/client` et `prisma` des dépendances ; `backend/prisma/schema.prisma` et `backend/prisma/migrations/` ; les scripts `db:generate` et `db:migrate` ; l'étape `npx prisma generate` de `backend/Dockerfile:41` et `backend/dev.Dockerfile:16` ; la commande `npx prisma migrate deploy` du service `db-migration` dans `docker-compose.yml:19` et `docker-compose.prod.yml:19`, remplacée par l'invocation du nouveau runner.
+
+`better-sqlite3` est un module natif : `backend/Dockerfile` installe déjà `python3 make g++` en étape de build, la chaîne est donc présente. L'étape d'exécution copie les `node_modules` de production — le binaire compilé doit y être ; à vérifier à l'implémentation, c'est le point de rupture le plus probable du build Docker.
+
+#### Ordre de travail, sous TDD
+
+1. Le runner de migrations et son test : base vide, base existante conforme, base existante divergente (qui doit échouer).
+2. Les cinq modules de dépôt, un par un, chacun avec ses tests contre un fichier SQLite temporaire. Les jointures d'abord, ce sont elles qui portent le risque.
+3. La bascule des appelants, un fichier à la fois, en s'appuyant sur les tests qui existent désormais.
+4. Suppression de Prisma une fois qu'aucun appelant ne le référence.
+
+**Vérification.** Les nouveaux tests de `backend/src/db/` ; les 12 suites `core/test` ; la suite Playwright, en particulier `room-authz.spec.ts` et `local-roms.spec.ts` ; `du -sh node_modules`, qui doit perdre environ 86 MB.
+
+### Étape 4 — #10 Partie 2, Bun comme runtime
+
+Hors périmètre de ce travail, et volontairement. À rouvrir une fois l'étape 3 livrée, quand le risque aura changé de nature : Prisma parti, le binaire natif du moteur de requêtes n'est plus un obstacle, et il ne reste que `socket.io` côté serveur sur la couche de compatibilité node de Bun, `pino` et ses transports en thread de travail, et le portage des suites de test vers `bun test`.
+
+Ce que l'étape 4 gagnerait alors : `tsx` et `dotenv` disparaissent, et `better-sqlite3` peut céder la place à `bun:sqlite` en ne touchant que `backend/src/db/`.
+
+## Mesures
+
+#11 demande de mesurer, faute de quoi l'exercice devient du rangement sans preuve. Relevé avant chaque étape et après :
+
+- `du -sh node_modules`
+- `grep -c '"node_modules/' package-lock.json`, ou l'équivalent Bun après l'étape 2
+- durée d'une installation à froid, cache vidé
+
+Point de départ, 18 août 2026 : **461 packages, 257 MB.**
+
+## Ce que cette conception ne fait pas
+
+- Elle ne touche pas aux modes Dual et Streaming, ni à `simple-peer`, ni aux polyfills qui les servent.
+- Elle ne migre pas le runtime vers Bun.
+- Elle n'ajoute ni transactions, ni `groupBy`, ni agrégats : les 50 appels n'en utilisent aucun, et les modules de dépôt n'exposeront que ce qui est appelé.
+- Elle ne modifie pas le schéma de la base. La baseline décrit l'existant, à l'identique.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,37 +16,40 @@ ENV VITE_WS_URL=$VITE_WS_URL
 
 # Copy package files and install all dependencies (including devDependencies for build)
 COPY package.json ./
-RUN bun install
+COPY backend/package.json ./backend/package.json
+COPY frontend/package.json ./frontend/package.json
+COPY bun.lock ./
+RUN bun install --frozen-lockfile --filter=./frontend
 
 # Copy source code and configuration
-COPY tsconfig.json ./
-COPY svelte.config.js ./
-COPY vite.config.ts ./
-COPY src ./src
-COPY static ./static
+COPY frontend/tsconfig.json ./frontend/tsconfig.json
+COPY frontend/svelte.config.js ./frontend/svelte.config.js
+COPY frontend/vite.config.ts ./frontend/vite.config.ts
+COPY frontend/src ./frontend/src
+COPY frontend/static ./frontend/static
 
 # Update PWA configuration for production build
-RUN sed -i "s/mode: 'development'/mode: 'production'/" vite.config.ts && \
-    sed -i "s/strategies: 'injectManifest'/strategies: 'generateSW'/" vite.config.ts
+RUN sed -i "s/mode: 'development'/mode: 'production'/" frontend/vite.config.ts && \
+    sed -i "s/strategies: 'injectManifest'/strategies: 'generateSW'/" frontend/vite.config.ts
 
 # Generate SvelteKit types (fixes tsconfig warning)
-RUN bunx svelte-kit sync
+RUN cd frontend && bunx svelte-kit sync
 
 # Build the SvelteKit app
-RUN bun run build
+RUN bun run --filter=./frontend build
 
 # Production stage with nginx
 FROM nginx:alpine
 
 # Copy nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Remove default nginx static files
 RUN rm -rf /usr/share/nginx/html/*
 
 # Copy built static assets from builder
 # SvelteKit with adapter-static creates static files in build/
-COPY --from=builder /app/build /usr/share/nginx/html
+COPY --from=builder /app/frontend/build /usr/share/nginx/html
 
 # Fix file permissions for nginx to read all files
 RUN chmod -R 644 /usr/share/nginx/html/* && \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,9 @@
 # Build stage
 FROM node:20-alpine AS builder
 
+COPY --from=oven/bun:1-alpine /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=oven/bun:1-alpine /usr/local/bin/bunx /usr/local/bin/bunx
+
 WORKDIR /app
 
 # Build arguments for Vite environment variables
@@ -12,9 +15,8 @@ ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_WS_URL=$VITE_WS_URL
 
 # Copy package files and install all dependencies (including devDependencies for build)
-COPY package*.json ./
-RUN npm install && \
-    npm cache clean --force
+COPY package.json ./
+RUN bun install
 
 # Copy source code and configuration
 COPY tsconfig.json ./
@@ -28,10 +30,10 @@ RUN sed -i "s/mode: 'development'/mode: 'production'/" vite.config.ts && \
     sed -i "s/strategies: 'injectManifest'/strategies: 'generateSW'/" vite.config.ts
 
 # Generate SvelteKit types (fixes tsconfig warning)
-RUN npx svelte-kit sync
+RUN bunx svelte-kit sync
 
 # Build the SvelteKit app
-RUN npm run build
+RUN bun run build
 
 # Production stage with nginx
 FROM nginx:alpine

--- a/frontend/dev.Dockerfile
+++ b/frontend/dev.Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20
+
+COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
+
+WORKDIR /app
+
+# Copy package files and install dependencies (cached until package.json changes).
+# The full workspace shape (root + both member manifests) is required: bun.lock
+# describes a 3-workspace root, and Bun discards/re-resolves against any context
+# that doesn't match that shape, silently floating every version.
+COPY package.json ./
+COPY backend/package.json ./backend/package.json
+COPY frontend/package.json ./frontend/package.json
+COPY bun.lock ./
+RUN bun install --frozen-lockfile --filter=./frontend
+
+# Source code will be mounted as a volume, so we don't copy it here
+
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,13 +17,9 @@
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "simple-peer": "^9.11.1",
-        "socket.io-client": "^4.7.2",
-        "stream-browserify": "^3.0.0",
-        "util": "^0.12.5"
+        "socket.io-client": "^4.7.2"
       },
       "devDependencies": {
-        "@sveltejs/adapter-auto": "^3.1.1",
-        "@sveltejs/adapter-node": "^5.0.1",
         "@sveltejs/adapter-static": "^3.0.1",
         "@sveltejs/kit": "^2.5.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.2",
@@ -360,94 +356,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/plugin-commonjs": {
-      "version": "28.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "commondir": "^1.0.1",
-        "estree-walker": "^2.0.2",
-        "fdir": "^6.2.0",
-        "is-reference": "1.2.1",
-        "magic-string": "^0.30.3",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0 || 14 >= 14.17"
-      },
-      "peerDependencies": {
-        "rollup": "^2.68.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-json": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "16.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "@types/resolve": "1.20.2",
-        "deepmerge": "^4.2.2",
-        "is-module": "^1.0.0",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.78.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.53.2",
       "cpu": [
@@ -475,31 +383,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
-      }
-    },
-    "node_modules/@sveltejs/adapter-auto": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-meta-resolve": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@sveltejs/kit": "^2.0.0"
-      }
-    },
-    "node_modules/@sveltejs/adapter-node": {
-      "version": "5.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/plugin-commonjs": "^28.0.1",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^16.0.0",
-        "rollup": "^4.9.5"
-      },
-      "peerDependencies": {
-        "@sveltejs/kit": "^2.4.0"
       }
     },
     "node_modules/@sveltejs/adapter-static": {
@@ -629,11 +512,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/resolve": {
-      "version": "1.20.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/simple-peer": {
       "version": "9.11.9",
       "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.9.tgz",
@@ -684,19 +562,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axobject-query": {
@@ -846,47 +711,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001755",
       "dev": true,
@@ -958,11 +782,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -1018,21 +837,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/detect-indent": {
       "version": "6.1.0",
       "dev": true,
@@ -1045,18 +849,6 @@
       "version": "5.5.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.255",
@@ -1103,30 +895,6 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
       "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
       "license": "MIT"
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
@@ -1185,11 +953,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -1197,22 +960,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/fill-range": {
@@ -1226,37 +973,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -1273,39 +993,6 @@
       "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
       "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
       "license": "MIT"
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1337,63 +1024,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -1415,15 +1049,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "dev": true,
@@ -1443,22 +1068,6 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "dev": true,
@@ -1470,53 +1079,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -1530,54 +1098,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-module": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-reference": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/js-tokens": {
@@ -1642,13 +1168,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/mdn-data": {
@@ -1768,11 +1287,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/periscopic": {
       "version": "3.1.0",
       "dev": true,
@@ -1803,24 +1317,6 @@
       "version": "1.1.1",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -1921,25 +1417,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/rimraf": {
       "version": "2.7.1",
       "dev": true,
@@ -2020,21 +1497,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/sander": {
       "version": "0.5.1",
       "dev": true,
@@ -2060,21 +1522,6 @@
       "version": "2.7.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/simple-peer": {
       "version": "9.11.1",
@@ -2239,16 +1686,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stream-browserify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.4",
-        "readable-stream": "^3.5.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2267,17 +1704,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/svelte": {
@@ -2504,19 +1930,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2592,25 +2005,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wrappy": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,13 +18,9 @@
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "simple-peer": "^9.11.1",
-    "socket.io-client": "^4.7.2",
-    "stream-browserify": "^3.0.0",
-    "util": "^0.12.5"
+    "socket.io-client": "^4.7.2"
   },
   "devDependencies": {
-    "@sveltejs/adapter-auto": "^3.1.1",
-    "@sveltejs/adapter-node": "^5.0.1",
     "@sveltejs/adapter-static": "^3.0.1",
     "@sveltejs/kit": "^2.5.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.2",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,14 +9,12 @@ export default defineConfig({
   resolve: {
     alias: {
       buffer: 'buffer/',
-      stream: 'stream-browserify',
       events: 'events',
-      util: 'util/',
       path: 'path-browserify',
     },
   },
   optimizeDeps: {
-    include: ['simple-peer', 'buffer', 'process', 'events', 'util', 'stream-browserify', 'ini', 'path-browserify'],
+    include: ['simple-peer', 'buffer', 'process', 'events', 'ini', 'path-browserify'],
     esbuildOptions: {
       define: {
         global: 'globalThis',

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,13 +64,9 @@
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "simple-peer": "^9.11.1",
-        "socket.io-client": "^4.7.2",
-        "stream-browserify": "^3.0.0",
-        "util": "^0.12.5"
+        "socket.io-client": "^4.7.2"
       },
       "devDependencies": {
-        "@sveltejs/adapter-auto": "^3.1.1",
-        "@sveltejs/adapter-node": "^5.0.1",
         "@sveltejs/adapter-static": "^3.0.1",
         "@sveltejs/kit": "^2.5.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.2",
@@ -1134,102 +1130,6 @@
         "@redis/client": "^1.0.0"
       }
     },
-    "node_modules/@rollup/plugin-commonjs": {
-      "version": "28.0.9",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz",
-      "integrity": "sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "commondir": "^1.0.1",
-        "estree-walker": "^2.0.2",
-        "fdir": "^6.2.0",
-        "is-reference": "1.2.1",
-        "magic-string": "^0.30.3",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0 || 14 >= 14.17"
-      },
-      "peerDependencies": {
-        "rollup": "^2.68.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-json": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
-      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
-      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "@types/resolve": "1.20.2",
-        "deepmerge": "^4.2.2",
-        "is-module": "^1.0.0",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.78.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.53.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.2.tgz",
@@ -1559,35 +1459,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
-      }
-    },
-    "node_modules/@sveltejs/adapter-auto": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.3.1.tgz",
-      "integrity": "sha512-5Sc7WAxYdL6q9j/+D0jJKjGREGlfIevDyHSQ2eNETHcB1TKlQWHcAo8AS8H1QdjNvSXpvOwNjykDUHPEAyGgdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-meta-resolve": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@sveltejs/kit": "^2.0.0"
-      }
-    },
-    "node_modules/@sveltejs/adapter-node": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.4.0.tgz",
-      "integrity": "sha512-NMsrwGVPEn+J73zH83Uhss/hYYZN6zT3u31R3IHAn3MiKC3h8fjmIAhLfTSOeNHr5wPYfjjMg8E+1gyFgyrEcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/plugin-commonjs": "^28.0.1",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^16.0.0",
-        "rollup": "^4.9.5"
-      },
-      "peerDependencies": {
-        "@sveltejs/kit": "^2.4.0"
       }
     },
     "node_modules/@sveltejs/adapter-static": {
@@ -1937,13 +1808,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/resolve": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
-      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -2072,21 +1936,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axobject-query": {
@@ -2323,24 +2172,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2465,13 +2296,6 @@
       "license": "MIT",
       "optional": true,
       "peer": true
-    },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -2629,23 +2453,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/depd": {
@@ -2972,13 +2779,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3089,24 +2889,6 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3136,21 +2918,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/forwarded": {
@@ -3200,15 +2967,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/generic-pool": {
@@ -3320,38 +3078,11 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3434,17 +3165,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3478,22 +3198,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3507,34 +3211,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3543,25 +3219,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -3577,13 +3234,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3592,49 +3242,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-reference": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/joycon": {
@@ -4029,13 +3636,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
@@ -4085,19 +3685,6 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/pino": {
       "version": "10.1.0",
@@ -4205,15 +3792,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -4500,27 +4078,6 @@
         "@redis/time-series": "1.1.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4666,23 +4223,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -4800,23 +4340,6 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -5234,16 +4757,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/stream-browserify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.4",
-        "readable-stream": "^3.5.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -5282,19 +4795,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/svelte": {
@@ -5620,19 +5120,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -6162,27 +5649,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wrappy": {


### PR DESCRIPTION
Phases 1 and 2 of the dependency work (issues #10 and #11). Phase 3 — replacing Prisma with `better-sqlite3` (#13) — continues on `deps-bun-sqlite` and is not in this PR.

## What changed

**Four frontend packages nothing imported** are gone: `@sveltejs/adapter-auto`, `@sveltejs/adapter-node`, `stream-browserify`, `util`, along with their `vite.config.ts` aliases. `events` was on the same list and **stays** — `simple-peer` pulls in `readable-stream`, whose browser build calls `require('events').EventEmitter` with no fallback, and Vite was silently stubbing it to an empty module rather than failing the build.

**Bun installs, Node still runs.** The three Dockerfiles copy the Bun binary from the official image (matching libc per stage — `oven/bun:1` for glibc, `oven/bun:1-alpine` for the musl builder) and install with `bun install --frozen-lockfile`. Every image is pinned to the single root `bun.lock`. A root `.dockerignore` was added so root-context builds stop shipping `node_modules` and `.git`.

**The dev containers no longer install anything at start.** The images install at build time and the volumes carry it, so the `npm install` that ran on every single container start is simply gone rather than made faster.

## Measured

- Cold `docker compose down -v` + `up -d`: **319s → 8s**
- Lockfile packages: 461 → 425

## Requires an infra change

`frontend/Dockerfile` now expects the repo root as its build context, so `psnes-online-infra`'s `deploy.yml` must build it with `context: ./app` instead of `context: ./app/frontend`. That change is being pushed alongside this merge.

## Verification

- `npm run test:all`: 83 passing
- Playwright e2e: 21/21 against the live stack
- Both compose files build; production image inspected directly — correct libc per stage, all 15 backend runtime dependencies present, devDependencies excluded, no frontend leakage

## Workflow change for developers

Adding a dependency now needs a rebuild rather than a restart. The recipe is documented in `README.md` and in comments on both compose `command:` lines — deliberately *not* `docker compose down -v`, which would also wipe the dev database, savestates, avatars and Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)