### PR TITLE
Fix the VR permission eject, guard the frame loop, and name the buttons nobody could find

### DIFF
--- a/core/test/rom-provider.test.ts
+++ b/core/test/rom-provider.test.ts
@@ -229,3 +229,37 @@ test('un stockage qui lève laisse une bibliothèque vide, pas une promesse reje
 	assert.deepEqual(await resolvableHere(), []);
 	useKeptFiles(null);
 });
+
+/* -------------------------------------- la permission d un dossier, en VR */
+
+/**
+ * A stored-folder handle whose `requestPermission` throws if it is ever
+ * called - the sharpest way to prove a code path never escalates to the
+ * native prompt, rather than merely observing that it "happened" not to.
+ */
+function fakeDirectoryHandle(granted: boolean) {
+	let requested = false;
+	const handle = {
+		queryPermission: async () => (granted ? 'granted' : 'prompt'),
+		requestPermission: async () => {
+			requested = true;
+			throw new Error('requestPermission must not be called on the non-prompting path');
+		}
+	};
+	return {
+		handle: handle as unknown as FileSystemDirectoryHandle,
+		wasRequested: () => requested
+	};
+}
+
+test('hasAccess answers from the query alone and never calls requestPermission', async () => {
+	const { hasAccess } = await import('../../frontend/src/lib/roms/local-library.js');
+	const ungranted = fakeDirectoryHandle(false);
+
+	assert.equal(await hasAccess(ungranted.handle), false);
+	assert.equal(ungranted.wasRequested(), false);
+
+	const granted = fakeDirectoryHandle(true);
+	assert.equal(await hasAccess(granted.handle), true);
+	assert.equal(granted.wasRequested(), false, 'already granted needs no request either');
+});

--- a/core/test/vr-panel-profile.test.ts
+++ b/core/test/vr-panel-profile.test.ts
@@ -19,6 +19,8 @@ import assert from 'node:assert/strict';
 import {
   layoutProfilePanel,
   drawProfilePanel,
+  fixedMapRows,
+  FIXED_COL_W,
   PROFILE_PANEL_SIZE
 } from '../../frontend/src/lib/vr/panels/profile.js';
 
@@ -27,23 +29,38 @@ const LABELS = {
   thumb: 'Thumb',
   quit: 'Leave VR',
   resume: 'Back to the game',
-  controls: 'Controls'
+  controls: 'Controls',
+  // The shipped English, not placeholders: two of the tests below measure
+  // these strings, and a short stand-in would pass a width check the real
+  // wording could fail.
+  gripLeft: 'Left grip',
+  gripRight: 'Right grip',
+  triggers: 'Triggers',
+  leftStick: 'Left stick',
+  dpad: 'D-pad'
 };
 
 function recordingContext() {
   const texts: string[] = [];
   const calls: string[] = [];
+  /** Where each string landed. `texts` alone cannot answer "does it fit". */
+  const placed: Array<{ text: string; x: number }> = [];
   return {
     texts,
     calls,
+    placed,
     font: '', fillStyle: '', strokeStyle: '', lineWidth: 0,
     textAlign: 'left', textBaseline: 'alphabetic',
     save() {}, restore() {}, clearRect() {}, fillRect() { calls.push('fillRect'); },
     strokeRect() { calls.push('strokeRect'); },
     beginPath() {}, arc() { calls.push('arc'); }, fill() {}, stroke() {},
-    fillText(text: string) { texts.push(text); },
+    fillText(text: string, x: number) { texts.push(text); placed.push({ text, x }); },
     measureText(text: string) { return { width: text.length * 9 }; }
-  } as unknown as CanvasRenderingContext2D & { texts: string[]; calls: string[] };
+  } as unknown as CanvasRenderingContext2D & {
+    texts: string[];
+    calls: string[];
+    placed: Array<{ text: string; x: number }>;
+  };
 }
 
 const IDLE = { pseudo: 'Ada', scheme: 'letters' as const, language: 'fr' as const, playing: false };
@@ -144,4 +161,59 @@ test('the active preset is marked, so a player can see what they have', () => {
   const strokes = (c: typeof plain) =>
     (c as unknown as { calls: string[] }).calls.filter((k) => k === 'strokeRect').length;
   assert.ok(strokes(hovered) > strokes(plain));
+});
+
+/*
+ * The two tests below exist because of a real hardware session, not a
+ * hypothesis. The cards draw the four face buttons - the mappings whose letter
+ * is printed on the controller, so the ones a player can already guess. START,
+ * SELECT, the shoulders and the d-pad were named nowhere in the headset, and
+ * START is on the right grip: the session ended with the controls reported
+ * dead when they were merely unlabelled.
+ */
+
+test('the four unguessable mappings are drawn under either preset', () => {
+  // Under both, because no preset moves them - a block that appeared only on
+  // one would leave half the players with nothing.
+  for (const scheme of ['letters', 'thumb'] as const) {
+    const state = { ...IDLE, scheme };
+    const ctx = recordingContext();
+    drawProfilePanel(ctx, state, layoutProfilePanel(state), { labels: LABELS, hoverId: null });
+    const drawn = (ctx as unknown as { texts: string[] }).texts;
+    for (const [hardware, snes] of fixedMapRows(LABELS)) {
+      assert.ok(
+        drawn.includes(`${hardware} \u2192 ${snes}`),
+        `${snes} is named nowhere with scheme=${scheme}, and nothing else in the headset names it`
+      );
+    }
+  }
+});
+
+test('the mapping rows clear the buttons on the right', () => {
+  // Measured where they actually landed rather than against the constant:
+  // this catches a long translation, a wrong column width, and the block
+  // drifting sideways, which a constant-only check would all miss.
+  const state = { ...IDLE, playing: true };
+  const quit = layoutProfilePanel(state).find((r) => r.id === 'quit');
+  assert.ok(quit, 'no quit region to measure against');
+
+  const ctx = recordingContext();
+  drawProfilePanel(ctx, state, layoutProfilePanel(state), { labels: LABELS, hoverId: null });
+  const placed = (ctx as unknown as { placed: Array<{ text: string; x: number }> }).placed;
+
+  for (const [hardware, snes] of fixedMapRows(LABELS)) {
+    const line = `${hardware} \u2192 ${snes}`;
+    const drawn = placed.find((p) => p.text === line);
+    assert.ok(drawn, `${line} was not drawn`);
+    // The same metric the fixture's own measureText uses.
+    const width = line.length * 9;
+    assert.ok(
+      width <= FIXED_COL_W,
+      `"${line}" needs ${width}px in a ${FIXED_COL_W}px column - shorten the wording`
+    );
+    assert.ok(
+      drawn!.x + width <= quit!.x,
+      `"${line}" reaches ${drawn!.x + width}px and the buttons start at ${quit!.x}px`
+    );
+  }
 });

--- a/frontend/src/lib/components/VrShell.svelte
+++ b/frontend/src/lib/components/VrShell.svelte
@@ -588,7 +588,11 @@
           // one lands on the flat page the player has just been dropped onto.
           notifications.show(t($language, 'vrContextLost'), 'error', 6000);
           void leave();
-        }
+        },
+        // The one witness to a throw out of the XR animation loop. Without it
+        // the loop's own guard would keep the world drawable and tell nobody
+        // why the game had stopped.
+        onFrameError: (err) => logger.error('vr frame', err)
       });
 
       session = await openVrSession(() => {

--- a/frontend/src/lib/components/VrShell.svelte
+++ b/frontend/src/lib/components/VrShell.svelte
@@ -310,8 +310,13 @@
        * `obtainRom()` answers that by opening `LocateRom`; in here there is no
        * modal to open, so the failure has to be a line on the panel. The game
        * stays in the grid: it exists, it just could not be read this time.
+       *
+       * `requestPermission: false` is not optional here: the trigger press that
+       * got us into `launch()` is a real gesture, so without this the browser's
+       * native permission dialog would fire and eject the player from the
+       * headset to show it - the exact interruption this panel exists to avoid.
        */
-      const rom = await resolveQuietly(game.crc32);
+      const rom = await resolveQuietly(game.crc32, { requestPermission: false });
       if (!rom) {
         launchNotice = t($language, 'vrRomUnreadable');
         repaintLibrary();

--- a/frontend/src/lib/components/VrShell.svelte
+++ b/frontend/src/lib/components/VrShell.svelte
@@ -217,7 +217,12 @@
           thumb: t($language, 'vrPresetThumb'),
           quit: t($language, 'vrQuit'),
           resume: t($language, 'vrResume'),
-          controls: t($language, 'controls')
+          controls: t($language, 'controls'),
+          gripLeft: t($language, 'vrGripLeft'),
+          gripRight: t($language, 'vrGripRight'),
+          triggers: t($language, 'vrTriggers'),
+          leftStick: t($language, 'vrLeftStick'),
+          dpad: t($language, 'vrDpad')
         },
         hoverId: hovered?.panel === 'profile' ? hovered.region.id : null
       })

--- a/frontend/src/lib/i18n/translations.ts
+++ b/frontend/src/lib/i18n/translations.ts
@@ -476,7 +476,14 @@ export const translations = {
     vrPresetLetters: 'Letters match',
     vrPresetThumb: 'Thumb comfort',
     vrQuit: 'Leave VR',
-    vrResume: 'Back to the game'
+    vrResume: 'Back to the game',
+    // Kept short: `vr/panels/profile.ts` draws these as `<this> -> <SNES>`
+    // inside a 228px column and does not wrap.
+    vrGripLeft: 'Left grip',
+    vrGripRight: 'Right grip',
+    vrTriggers: 'Triggers',
+    vrLeftStick: 'Left stick',
+    vrDpad: 'D-pad'
   },
   fr: {
     // Legal disclaimer
@@ -940,7 +947,12 @@ export const translations = {
     vrPresetLetters: 'Fidèle aux lettres',
     vrPresetThumb: 'Confort du pouce',
     vrQuit: 'Quitter la VR',
-    vrResume: 'Retour au jeu'
+    vrResume: 'Retour au jeu',
+    vrGripLeft: 'Grip gauche',
+    vrGripRight: 'Grip droit',
+    vrTriggers: 'Gâchettes',
+    vrLeftStick: 'Stick gauche',
+    vrDpad: 'Croix'
   }
 };
 

--- a/frontend/src/lib/roms/local-library.ts
+++ b/frontend/src/lib/roms/local-library.ts
@@ -120,17 +120,32 @@ export async function storedDirectory(): Promise<FileSystemDirectoryHandle | und
 }
 
 /**
+ * Whether a stored folder's read permission is granted right now, without
+ * ever asking for it.
+ *
+ * Split out of `ensureAccess` so a caller that must not risk the native
+ * permission prompt - even off the back of a real user gesture, because the
+ * prompt itself is the harm, not just the gesture requirement - can stop at
+ * the query and treat anything short of `granted` as absent.
+ */
+export async function hasAccess(handle: FileSystemDirectoryHandle): Promise<boolean> {
+	const withPermissions = handle as unknown as {
+		queryPermission(d: { mode: string }): Promise<PermissionState>;
+	};
+	return (await withPermissions.queryPermission({ mode: 'read' })) === 'granted';
+}
+
+/**
  * Re-grants read permission on a stored folder.
  *
  * Returns false when the browser wants a fresh gesture, which is not an error
  * - it is the normal state at the start of a session.
  */
 export async function ensureAccess(handle: FileSystemDirectoryHandle): Promise<boolean> {
+	if (await hasAccess(handle)) return true;
 	const withPermissions = handle as unknown as {
-		queryPermission(d: { mode: string }): Promise<PermissionState>;
 		requestPermission(d: { mode: string }): Promise<PermissionState>;
 	};
-	if ((await withPermissions.queryPermission({ mode: 'read' })) === 'granted') return true;
 	try {
 		return (await withPermissions.requestPermission({ mode: 'read' })) === 'granted';
 	} catch {

--- a/frontend/src/lib/roms/provider.ts
+++ b/frontend/src/lib/roms/provider.ts
@@ -21,6 +21,7 @@
 import { crc32, normaliseRom } from './checksum.js';
 import {
 	ensureAccess,
+	hasAccess,
 	indexedChecksums,
 	readRomByChecksum,
 	romBytes,
@@ -87,13 +88,34 @@ export function isCached(checksum: string): boolean {
 }
 
 /**
+ * Options for {@link resolveQuietly}.
+ */
+export interface ResolveQuietlyOptions {
+	/**
+	 * Whether a lapsed folder permission may be re-requested.
+	 *
+	 * Defaults to true - re-granting from the gesture that triggered the
+	 * launch is how a flat page recovers a folder permission that lapsed
+	 * between sessions, and it is the behaviour every existing caller relies
+	 * on. Pass false only where the browser's own permission dialog would
+	 * itself be the problem: in the immersive VR session, a `select` event is
+	 * a real user gesture, so `requestPermission` does not fail quietly there
+	 * - it shows the native prompt and throws the player out of the headset.
+	 */
+	requestPermission?: boolean;
+}
+
+/**
  * Finds a ROM without asking the player anything.
  *
  * Returns null rather than throwing when it comes up empty: not finding the
  * file is the expected state on a browser with no folder picker, and the
  * caller's job is then to ask.
  */
-export async function resolveQuietly(checksum: string): Promise<Uint8Array | null> {
+export async function resolveQuietly(
+	checksum: string,
+	options?: ResolveQuietlyOptions
+): Promise<Uint8Array | null> {
 	const cached = cache.get(checksum);
 	if (cached) return cached;
 
@@ -118,9 +140,15 @@ export async function resolveQuietly(checksum: string): Promise<Uint8Array | nul
 		const handle = await storedDirectory();
 		if (!handle) return null;
 
-		// Permission on a stored folder lapses between sessions, and re-granting it
-		// needs a user gesture we do not have here. Silence is the correct answer.
-		if (!(await ensureAccess(handle))) return null;
+		// Permission on a stored folder lapses between sessions. Whether it is
+		// worth re-requesting is not this function's call to make - it is the
+		// caller's, via `options.requestPermission` - because only the caller
+		// knows whether a native permission prompt right now is recoverable
+		// (a flat page) or a disaster (an immersive session with no page behind
+		// it to show the prompt on).
+		const granted =
+			options?.requestPermission === false ? await hasAccess(handle) : await ensureAccess(handle);
+		if (!granted) return null;
 
 		const bytes = await readRomByChecksum(handle, checksum);
 		if (bytes) cache.set(checksum, bytes);

--- a/frontend/src/lib/vr/panels/profile.ts
+++ b/frontend/src/lib/vr/panels/profile.ts
@@ -14,6 +14,11 @@
  * canvas is already being drawn, so it is nearly free - which is exactly why
  * the spec chose to do it here rather than in a help page nobody opens.
  *
+ * Below the cards sit the four mappings no preset changes - START, SELECT,
+ * the shoulders and the d-pad. They are here because they are the only ones a
+ * player cannot guess: the face buttons have their letter printed under the
+ * thumb, and these have nothing printed anywhere. See `fixedMapRows`.
+ *
  * What is deliberately absent: the ROM source (there is no file picker in an
  * immersive session), the portable config (files), account deletion (a
  * destructive action behind a confirmation), and per-button rebinding (the
@@ -50,6 +55,14 @@ export interface ProfileLabels {
   quit: string;
   resume: string;
   controls: string;
+  /* The four rows below the cards. Kept short on purpose: `fixedMapRows`
+   * renders each as `<hardware> -> <SNES>` inside FIXED_COL_W, and a long
+   * translation runs into the quit button rather than wrapping. */
+  gripLeft: string;
+  gripRight: string;
+  triggers: string;
+  leftStick: string;
+  dpad: string;
 }
 
 /** What each preset puts on the four Touch face buttons, for the diagram.
@@ -61,6 +74,36 @@ const DIAGRAM: Record<VrPadScheme, Array<[string, string]>> = {
   letters: [['Y', 'Y'], ['X', 'X'], ['B', 'B'], ['A', 'A']],
   thumb: [['Y', 'X'], ['X', 'Y'], ['B', 'A'], ['A', 'B']]
 };
+
+/** The strip under the two cards, clear of the buttons on the right. */
+const FIXED_Y = CARD_Y + CARD_H + 26;
+const FIXED_ROW_H = 30;
+export const FIXED_COL_W = 228;
+
+/**
+ * The mappings no preset changes - and the ones that actually needed showing.
+ *
+ * The two cards draw the four face buttons, which are the mappings a player
+ * can already guess, because the letter is printed on the controller under
+ * their thumb. START, SELECT, the shoulders and the d-pad have nothing
+ * printed anywhere and no preset moves them, so before this block the headset
+ * named them nowhere at all. That is not hypothetical: START sits on the
+ * right grip, the one button nobody thinks to squeeze, and a whole hardware
+ * test session was spent concluding the controls were dead when they were
+ * merely unlabelled.
+ *
+ * `vr/pad.ts` remains the single source of truth for every mapping here; this
+ * is its picture. Exported so the test can measure the rows against
+ * FIXED_COL_W, which is how the cards' own overlap bug was caught.
+ */
+export function fixedMapRows(labels: ProfileLabels): Array<[string, string]> {
+  return [
+    [labels.gripRight, 'START'],
+    [labels.gripLeft, 'SELECT'],
+    [labels.triggers, 'L / R'],
+    [labels.leftStick, labels.dpad]
+  ];
+}
 
 export function layoutProfilePanel(state: ProfileState): Region[] {
   const regions: Region[] = [];
@@ -167,6 +210,22 @@ function drawButton(
   }
 }
 
+function drawFixedMap(ctx: CanvasRenderingContext2D, labels: ProfileLabels): void {
+  ctx.font = '17px system-ui, sans-serif';
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  fixedMapRows(labels).forEach(([hardware, snes], index) => {
+    const column = index % 2;
+    const row = Math.floor(index / 2);
+    ctx.fillStyle = '#c2c2d2';
+    ctx.fillText(
+      `${hardware} → ${snes}`,
+      PAD + IDENTITY_W + column * FIXED_COL_W,
+      FIXED_Y + row * FIXED_ROW_H
+    );
+  });
+}
+
 export function drawProfilePanel(
   ctx: CanvasRenderingContext2D,
   state: ProfileState,
@@ -213,6 +272,8 @@ export function drawProfilePanel(
         break;
     }
   }
+
+  drawFixedMap(ctx, opts.labels);
 
   ctx.restore();
 }

--- a/frontend/src/lib/vr/scene.ts
+++ b/frontend/src/lib/vr/scene.ts
@@ -47,6 +47,13 @@ export function createVrScene(opts: {
   aspect: PixelAspect;
   eyeHeight?: number;
   onContextLost: () => void;
+  /**
+   * A throw that escaped the pumped emulation slice or a per-frame callback.
+   *
+   * Reported, never swallowed: the loop below keeps drawing regardless, and
+   * without this the player would be the only witness.
+   */
+  onFrameError: (err: unknown) => void;
 }): VrScene {
   const layout = sceneLayout(opts.aspect, opts.eyeHeight);
 
@@ -76,6 +83,33 @@ export function createVrScene(opts: {
 
   const pump = createFramePump();
   const perFrame: Array<() => void> = [];
+
+  /*
+   * Why the render is outside the try below.
+   *
+   * A throw from the pumped slice or from a per-frame callback used to take
+   * `renderer.render()` down with it, and that is the worst shape this loop
+   * can fail in: the player is left inside a world that has stopped
+   * redrawing - frozen, or black if no frame ever arrived - with the panels
+   * unusable and the exit unreachable, because both of those are drawn by the
+   * render that no longer happens. Whatever the emulator did, the world still
+   * draws, so the right stick still recalls the panels and `quit` still
+   * works.
+   *
+   * Reported once per session. The two throwing paths differ in what they do
+   * next and neither wants repeating: a slice that throws never reaches the
+   * `schedule()` that ends `FrameGovernor.slice()`, so it is already dead and
+   * will never throw again, while a per-frame callback throws afresh on every
+   * one of the next seventy-two frames a second. Logging each of those would
+   * bury the first line - the only one that names the cause - and blow
+   * straight past `log-shipper.ts`'s hundred-entry batch.
+   */
+  let frameErrorReported = false;
+  function reportFrameError(err: unknown): void {
+    if (frameErrorReported) return;
+    frameErrorReported = true;
+    opts.onFrameError(err);
+  }
 
   const panels: PanelMesh[] = [];
   // Rebuilt only in `addPanel`, never inside `aimedAt`: that loop runs twice
@@ -174,8 +208,12 @@ export function createVrScene(opts: {
       renderer.setAnimationLoop(() => {
         // Order matters: the governor may run a frame, and the render should
         // show that frame rather than the previous one.
-        pump.pump();
-        for (const fn of perFrame) fn();
+        try {
+          pump.pump();
+          for (const fn of perFrame) fn();
+        } catch (err) {
+          reportFrameError(err);
+        }
         renderer.render(scene, camera);
       });
     },


### PR DESCRIPTION
Three fixes from the first real hardware session on a Quest 3, after #26 shipped.

## The bug that ejected the player

Clicking a game in the VR library threw the player out of the headset to a native file-permission dialog.

`resolveQuietly` promised silence in its name and did not keep it. Its comment read:

> Permission on a stored folder lapses between sessions, and re-granting it needs a user gesture we do not have here. Silence is the correct answer.

True where the flat page calls it. **False in VR** — the trigger press that launched the game *is* a user gesture, so `requestPermission` did not fail quietly; it asked, and an immersive session cannot render a native prompt. The spec promised "une notice dans le panneau, jamais une modale", and a native prompt is worse than a modal because it ejects.

Whether a lapsed permission is worth re-requesting is the caller's call, not the function's: only the caller knows whether a prompt right now is recoverable (a flat page, where it is the normal way to re-grant a folder) or a disaster. So it becomes an option defaulting to today's behaviour — **the four flat call sites are untouched, diff-empty** — and the VR path queries without ever asking. The `vrRomUnreadable` notice already worded this cause correctly.

## The guard that closes no bug

The XR animation loop pumped the governor, ran its per-frame callbacks, and then rendered — all unguarded. A throw from any of them took `renderer.render()` down with it: the player left inside a world that has stopped redrawing, with the panels unusable and the exit unreachable, because the render that draws both no longer runs. And nothing written anywhere to say why.

The render now happens whatever the emulator did, and the error is named in the log the client ships. Reported once per session — a per-frame callback would otherwise throw 72 times a second, burying the one line that names the cause and blowing past `log-shipper.ts`'s 100-entry batch.

This fixes nothing known. It is what would have made the last report legible: a black headset was reported and the logs had nothing in them, because there was nothing to have.

## The mapping nobody could find

The profile band already drew a controller diagram — and it drew exactly the mappings a player does not need: the four face buttons, whose letter is printed on the controller under their thumb. START, SELECT, the shoulders and the d-pad have nothing printed anywhere, no preset moves them, and the headset named them in no place at all.

The session ended with the controls reported dead. No button had any effect. They were not dead: the game was waiting on START, START is the right grip, and squeezing the grip is the last thing anyone tries. The spec's line was that there would be nothing to configure because it would just work — a mapping nobody can find fails that as surely as a broken one.

```
Right grip  → START        Triggers    → L / R
Left grip   → SELECT       Left stick  → D-pad
```

Drawn under either preset, since neither moves them. `vr/pad.ts` stays the single source of truth; this is its picture.

## Not a bug

Two other things from the session turned out not to be defects. A ROM that showed a black screen boots nowhere at all — it was a dead file, since deleted. And the controls were the mapping problem above, not a code path.

## Verification

- 550 tests pass (+2 new), 0 failures
- `svelte-check`: 0 errors, 15 warnings across 9 files — the unchanged baseline
- `bun run build` succeeds, and the dev container was confirmed to serve the touched modules
- The four flat `resolveQuietly` call sites have an empty diff
- **Not verified:** the mapping block's visual placement in a headset. The clearance test measures where the strings land using a 9px-per-character proxy, not the real font, so it guards against a long translation running into the buttons — not against ugly alignment.
