### PR TITLE
Let either thumbstick steer, and correct four comments that were wrong about the Quest prompt

### DIFF
--- a/core/test/vr-pad.test.ts
+++ b/core/test/vr-pad.test.ts
@@ -103,8 +103,38 @@ test('the stick has to be pushed past the threshold to count', () => {
   assert.equal(readVrPad([controller('left', { stick: [over, 0] })], 'letters', 'visible'), PAD.RIGHT);
 });
 
-test('only the left stick steers', () => {
-  assert.equal(readVrPad([controller('right', { stick: [-1, 0] })], 'letters', 'visible'), 0);
+test('either stick steers', () => {
+  // The right one too, and this is the ergonomics rather than a convenience:
+  // see `steer`. Reported from actual play.
+  assert.equal(readVrPad([controller('right', { stick: [-1, 0] })], 'letters', 'visible'), PAD.LEFT);
+  assert.equal(readVrPad([controller('left', { stick: [-1, 0] })], 'letters', 'visible'), PAD.LEFT);
+});
+
+test('the right stick steers while the left thumb works the buttons', () => {
+  // The whole reason for the change. With only the left stick on the d-pad,
+  // SNES X and Y - which live on the left controller's face - could not be
+  // pressed while moving at all.
+  const both = [
+    controller('right', { stick: [0, 1] }),
+    controller('left', { buttons: [4, 5] })
+  ];
+  assert.equal(readVrPad(both, 'letters', 'visible'), PAD.DOWN | PAD.X | PAD.Y);
+});
+
+test('two sticks pushed against each other report both directions', () => {
+  // Accepted, not prevented: real hardware does the same when somebody holds
+  // left and right together, and it takes a deliberate act to produce.
+  const fighting = [
+    controller('left', { stick: [-1, 0] }),
+    controller('right', { stick: [1, 0] })
+  ];
+  assert.equal(readVrPad(fighting, 'letters', 'visible'), PAD.LEFT | PAD.RIGHT);
+});
+
+test('a stick on neither hand steers nothing', () => {
+  // `handedness` is still the gate. A tracked source that is neither hand can
+  // carry a gamepad, and it has no business driving the d-pad.
+  assert.equal(readVrPad([controller('none', { stick: [-1, 0] })], 'letters', 'visible'), 0);
 });
 
 test('a blurred session reads as nothing held', () => {

--- a/core/test/vr-panel-profile.test.ts
+++ b/core/test/vr-panel-profile.test.ts
@@ -36,7 +36,7 @@ const LABELS = {
   gripLeft: 'Left grip',
   gripRight: 'Right grip',
   triggers: 'Triggers',
-  leftStick: 'Left stick',
+  sticks: 'Either stick',
   dpad: 'D-pad'
 };
 

--- a/core/test/vr-xr-session.test.ts
+++ b/core/test/vr-xr-session.test.ts
@@ -3,10 +3,11 @@
  *
  * Two rules, both learned from what goes wrong without them.
  *
- * Only `local` is asked for, and nothing is negotiated. Wanting a floor is
- * what makes the Quest demand a boundary before every entry, and the floor
- * bought nothing: the scene was placed from a guessed 1.6 m eye height, wrong
- * for anybody sitting down. `layout.ts` now measures from the eyes instead.
+ * Only `local` is asked for, and nothing is negotiated. `layout.ts` measures
+ * every height from the eyes, so no floor is wanted - and the 1.6 m eye
+ * height the floor path guessed was wrong for a seated player anyway. This
+ * does NOT stop the Quest asking which boundary to use: that dialog is the
+ * system's own Guardian and no web API reaches it.
  *
  * And `onEnd` fires exactly once. The system menu ending a session, the player
  * pressing quit, and the headset being put down all arrive as the same `end`
@@ -55,17 +56,16 @@ function fakeNavigator(session: ReturnType<typeof fakeSession>) {
 
 test('only the stationary space is asked for, and no feature is negotiated', async () => {
   /*
-   * Asking for a floor is what makes the Quest demand a boundary before every
-   * entry, and the floor bought nothing: the scene was placed from a guessed
-   * 1.6 m eye height, wrong for anybody sitting down. `local` is guaranteed
-   * for an immersive session, so there is nothing left to negotiate and no
-   * degradation to fall back from.
+   * `local` is guaranteed for an immersive session, and the geometry is
+   * eye-relative, so there is nothing left to negotiate and no degradation to
+   * fall back from. A negotiated feature is one more thing that can be
+   * refused by a headset for no benefit here.
    */
   const session = fakeSession({ spaces: ['local'] });
   const nav = fakeNavigator(session);
   const vr = await openVrSession(() => {}, nav);
 
-  assert.deepEqual(session.asked, ['local'], 'local-floor is what triggers the boundary prompt');
+  assert.deepEqual(session.asked, ['local'], 'a floor would be a height nothing needs');
 
   const init = nav.inits[0] as
     | { requiredFeatures?: string[]; optionalFeatures?: string[] }

--- a/frontend/src/lib/components/VrShell.svelte
+++ b/frontend/src/lib/components/VrShell.svelte
@@ -221,7 +221,7 @@
           gripLeft: t($language, 'vrGripLeft'),
           gripRight: t($language, 'vrGripRight'),
           triggers: t($language, 'vrTriggers'),
-          leftStick: t($language, 'vrLeftStick'),
+          sticks: t($language, 'vrSticks'),
           dpad: t($language, 'vrDpad')
         },
         hoverId: hovered?.panel === 'profile' ? hovered.region.id : null

--- a/frontend/src/lib/i18n/translations.ts
+++ b/frontend/src/lib/i18n/translations.ts
@@ -484,7 +484,7 @@ export const translations = {
     vrGripLeft: 'Left grip',
     vrGripRight: 'Right grip',
     vrTriggers: 'Triggers',
-    vrLeftStick: 'Left stick',
+    vrSticks: 'Either stick',
     vrDpad: 'D-pad'
   },
   fr: {
@@ -955,7 +955,7 @@ export const translations = {
     vrGripLeft: 'Grip gauche',
     vrGripRight: 'Grip droit',
     vrTriggers: 'Gâchettes',
-    vrLeftStick: 'Stick gauche',
+    vrSticks: 'Un des sticks',
     vrDpad: 'Croix'
   }
 };

--- a/frontend/src/lib/vr/layout.ts
+++ b/frontend/src/lib/vr/layout.ts
@@ -47,13 +47,12 @@ export interface SceneLayout {
  *
  * That follows from the reference space: `xr-session.ts` asks for `local`
  * only, whose origin is the head's pose when the session opens, so y = 0 is
- * eye level. It used to ask for `local-floor` and place the scene from a
- * guessed 1.6 m eye height, which cost a prompt the player had to answer on
- * every entry - the Quest asks which boundary to use the moment an app wants
- * a real floor - and got the height wrong for anybody sitting down.
+ * eye level. It used to ask for `local-floor` and place everything from a
+ * guessed 1.6 m eye height, which was wrong for anybody sitting down - and
+ * which the old `local` fallback would have hung a full 1.6 m overhead.
  *
- * Eye-relative removes both. There is no height left to guess: the scene is
- * placed where the head actually was.
+ * There is no height left to guess: the scene is placed where the head
+ * actually was.
  */
 
 const SCREEN_RADIUS = 2.5;

--- a/frontend/src/lib/vr/pad.ts
+++ b/frontend/src/lib/vr/pad.ts
@@ -59,6 +59,36 @@ function held(source: PadLikeSource, index: number): boolean {
   return source.gamepad?.buttons[index]?.pressed === true;
 }
 
+/**
+ * The d-pad contribution of one thumbstick.
+ *
+ * Called for BOTH hands, and that is ergonomics rather than generosity. With
+ * only the left stick steering, the left thumb is occupied for as long as the
+ * player is moving - and SNES X and Y live on the left controller's face, so
+ * half the button map was unreachable in motion. Reported from actual play.
+ *
+ * The objection this replaces was that a d-pad on both hands "would fight
+ * itself the moment a player rested a thumb on the right one". It does not: a
+ * resting thumb reads about zero and never crosses XR_AXIS_THRESHOLD. Getting
+ * a conflict takes pushing both sticks in opposite directions at once, which
+ * is deliberate, and which the caller's OR then reports as both directions
+ * held - exactly what real hardware does when somebody presses left and right
+ * together.
+ *
+ * Still only from a hand: `handedness` is checked at the call sites, so an
+ * input source that is neither left nor right never steers.
+ */
+function steer(gamepad: NonNullable<PadLikeSource['gamepad']>): PadMask {
+  let mask = 0;
+  const x = gamepad.axes[STICK_X] ?? 0;
+  const y = gamepad.axes[STICK_Y] ?? 0;
+  if (x <= -XR_AXIS_THRESHOLD) mask |= PAD.LEFT;
+  if (x >= XR_AXIS_THRESHOLD) mask |= PAD.RIGHT;
+  if (y <= -XR_AXIS_THRESHOLD) mask |= PAD.UP;
+  if (y >= XR_AXIS_THRESHOLD) mask |= PAD.DOWN;
+  return mask;
+}
+
 export function readVrPad(
   sources: Iterable<PadLikeSource>,
   scheme: VrPadScheme,
@@ -76,20 +106,15 @@ export function readVrPad(
     if (!source.gamepad) continue;
 
     if (source.handedness === 'left') {
+      mask |= steer(source.gamepad);
       if (held(source, FACE_UPPER)) mask |= face.left[0];
       if (held(source, FACE_LOWER)) mask |= face.left[1];
       if (held(source, TRIGGER)) mask |= PAD.L;
       if (held(source, SQUEEZE)) mask |= PAD.SELECT;
-
-      // Only the left stick steers: a d-pad on both hands would fight itself
-      // the moment a player rested a thumb on the right one.
-      const x = source.gamepad.axes[STICK_X] ?? 0;
-      const y = source.gamepad.axes[STICK_Y] ?? 0;
-      if (x <= -XR_AXIS_THRESHOLD) mask |= PAD.LEFT;
-      if (x >= XR_AXIS_THRESHOLD) mask |= PAD.RIGHT;
-      if (y <= -XR_AXIS_THRESHOLD) mask |= PAD.UP;
-      if (y >= XR_AXIS_THRESHOLD) mask |= PAD.DOWN;
     } else if (source.handedness === 'right') {
+      // The right stick steers so the LEFT thumb is free for X and Y. That is
+      // the whole point of `steer` being called twice.
+      mask |= steer(source.gamepad);
       if (held(source, FACE_UPPER)) mask |= face.right[0];
       if (held(source, FACE_LOWER)) mask |= face.right[1];
       if (held(source, TRIGGER)) mask |= PAD.R;

--- a/frontend/src/lib/vr/panels/profile.ts
+++ b/frontend/src/lib/vr/panels/profile.ts
@@ -61,7 +61,7 @@ export interface ProfileLabels {
   gripLeft: string;
   gripRight: string;
   triggers: string;
-  leftStick: string;
+  sticks: string;
   dpad: string;
 }
 
@@ -101,7 +101,7 @@ export function fixedMapRows(labels: ProfileLabels): Array<[string, string]> {
     [labels.gripRight, 'START'],
     [labels.gripLeft, 'SELECT'],
     [labels.triggers, 'L / R'],
-    [labels.leftStick, labels.dpad]
+    [labels.sticks, labels.dpad]
   ];
 }
 

--- a/frontend/src/lib/vr/scene.ts
+++ b/frontend/src/lib/vr/scene.ts
@@ -9,9 +9,9 @@
  *
  * The reference space is `local`, set here to match what `xr-session.ts`
  * asked for. Both have to say the same thing: three requests its own space
- * rather than reusing the session's, so a floor-relative type here would ask
- * for a space this session was never granted - and asking for a floor at all
- * is what makes the Quest demand a boundary before every entry.
+ * rather than reusing the session's (`WebXRManager.js`, whose default is
+ * `local-floor`), so a floor-relative type here would ask for a space this
+ * session was never granted.
  */
 
 import * as THREE from 'three';
@@ -201,9 +201,10 @@ export function createVrScene(opts: {
     onFrame: (fn) => void perFrame.push(fn),
 
     async attach(session: XRSession): Promise<void> {
-      // `local`, matching what `xr-session.ts` asked for. Anything
-      // floor-relative here would make three request a space the session was
-      // never granted, and it is also what makes the Quest demand a boundary.
+      // `local`, matching what `xr-session.ts` asked for, and BEFORE
+      // `setSession`: three requests its own space from inside that call, and
+      // its default is `local-floor`, so setting this afterwards would ask
+      // for a space the session was never granted.
       renderer.xr.setReferenceSpaceType('local');
       await renderer.xr.setSession(session);
       renderer.setAnimationLoop(() => {

--- a/frontend/src/lib/vr/xr-session.ts
+++ b/frontend/src/lib/vr/xr-session.ts
@@ -1,16 +1,18 @@
 /**
  * The life of one immersive session, and nothing about its contents.
  *
- * `local` is the only space asked for, and that is a decision rather than a
- * fallback. Wanting a real floor is what makes the Quest ask which boundary to
- * use, on every single entry, before the player can get in - and the floor
- * bought nothing: the scene was placed from a guessed 1.6 m eye height, which
- * is wrong for anybody sitting down. `local` is the stationary space, its
- * origin is the head's pose when the session opens, and `layout.ts` measures
- * every distance from the eyes. Nothing is guessed and nothing is asked.
+ * `local` is the only space asked for. The geometry in `layout.ts` is measured
+ * from the eyes, so there is no floor height left to want, and `local` is
+ * guaranteed for an immersive session by the WebXR spec - nothing to
+ * negotiate, nothing to fall back from.
  *
- * `local` is also guaranteed for an immersive session by the WebXR spec, so
- * there is no longer a degradation to handle, and no feature to negotiate.
+ * It was changed hoping to stop the Quest asking which boundary to use before
+ * every entry. It did not: that dialog is the system's own Guardian - "enter
+ * the nearby boundary or resume where you left off" - it never names the site,
+ * and it appears whatever the page requests. No web API reaches it. The change
+ * is kept on its own merits, which are real: the old `local` fallback placed
+ * the whole scene at a floor-relative height and would have hung it overhead,
+ * and the 1.6 m eye height it guessed was wrong for a seated player.
  *
  * `onEnd` fires exactly once, whatever ended the session. The system menu, the
  * quit button and a headset set down on the table all arrive as the same `end`


### PR DESCRIPTION
Both from playing on a real Quest 3 after #28 shipped.

## Either thumbstick steers

With only the left stick on the d-pad, the left thumb is occupied for as long as the player is moving — and SNES X and Y live on the left controller's face. **Half the button map was unreachable in motion.**

The objection this removes was mine, and it was weak:

> Only the left stick steers: a d-pad on both hands would fight itself the moment a player rested a thumb on the right one.

It does not. A resting thumb reads about zero and never crosses `XR_AXIS_THRESHOLD`. Getting a conflict takes pushing both sticks in opposite directions at once, which is deliberate — and the mask then reports both directions held, exactly what real hardware does when somebody presses left and right together. That case is now **tested rather than prevented**. A certain cost was being traded away for a corner case the player has to construct on purpose.

`handedness` is still the gate: `steer` is called from the two hand branches, so a tracked source that is neither left nor right carries no d-pad. The profile band's row becomes "Either stick", because "Left stick" would now be false.

## Four comments that were simply wrong

I wrote, in four places, that asking for `local-floor` is what makes the Quest demand a boundary before every entry. **It is not.** The dialog is the system's own Guardian — *"enter the nearby boundary or resume where you left off"*, offering a roomscale or a stationary boundary — it never names the site, and it still appears with the floor request gone. No web API reaches it.

Verified before writing the correction: the page asks `requestSession('immersive-vr')` with no init at all, then `requestReferenceSpace('local')`, and three's `WebXRManager` — whose own default is `local-floor` — is overridden to `local` before `setSession`, so its request is `local` too. Nothing anywhere still asks for a floor or a boundary.

This is the same defect I criticised in `resolveQuietly`'s comment in #27: a plausible causal claim, written with confidence, never checked. Shipping it was worse than leaving the question open, because the next reader would have believed it and stopped looking.

The comments now say what is true, including that the change is kept for the two things it *did* fix: the old `local` fallback would have hung the whole scene 1.6 m overhead, and the eye height it guessed was wrong for a seated player. Comments only in that commit — no behaviour change.

## Verification

- 564 tests pass (+3 net: one test replaced by four), 0 failures
- `svelte-check`: 0 errors, 15 warnings across 9 files — the unchanged baseline
- `bun run build` succeeds

## Still open, and not fixable here

The boundary prompt itself. It is a device-level dialog, no setting to disable it turned up, and the page has no lever. Worth stating plainly rather than attempting a third time.
