### PR TITLE
Say that the experience is played seated, since WebXR cannot enforce it

### DIFF
--- a/frontend/src/lib/components/TopBar.svelte
+++ b/frontend/src/lib/components/TopBar.svelte
@@ -144,9 +144,17 @@
       <!-- Capability, never a user agent: this button appears on a Quest and
            on a PC with a headset plugged in, and the "two controllers and
            nothing else" assumption only has to hold inside the session. -->
-      <button class="bar-button" on:click={enterVr}>
+      <button
+        class="bar-button"
+        title={t($language, 'vrSeatedTitle')}
+        on:click={enterVr}
+      >
         {t($language, 'enterVr')}
       </button>
+      <!-- Beside the button, not under it: this bar is a centred flex row and a
+           second line would change its height on every page. Only rendered
+           where the button is, so a PC with no headset never sees it. -->
+      <span class="vr-hint">{t($language, 'vrSeatedHint')}</span>
     {/if}
 
     <button class="bar-button" class:on={showFriends} on:click={toggleFriends}>
@@ -228,6 +236,22 @@
     padding: 0.35rem 0.7rem;
     border-radius: 6px;
     cursor: pointer;
+  }
+
+  /* Quiet on purpose: it is a caption for the button next to it, not a
+     control, and the bar already has enough things asking to be pressed. */
+  .vr-hint {
+    color: #8a8a98;
+    font-size: 0.78rem;
+    white-space: nowrap;
+  }
+
+  /* The bar is tight on a phone, and this is the one thing in it that is
+     advice rather than function - so it is the first thing to go. */
+  @media (max-width: 640px) {
+    .vr-hint {
+      display: none;
+    }
   }
 
   .bar-button.on {

--- a/frontend/src/lib/i18n/translations.ts
+++ b/frontend/src/lib/i18n/translations.ts
@@ -485,6 +485,12 @@ export const translations = {
     vrGripRight: 'Right grip',
     vrTriggers: 'Triggers',
     vrSticks: 'Either stick',
+    // Shown beside the VR button, for the reason WebXR cannot help with: the
+    // standard gives a page no way to keep a player in their chair, so saying
+    // so is the only thing that works.
+    vrSeatedHint: 'Played seated or standing still',
+    vrSeatedTitle:
+      'This experience is designed to be played seated or standing still, so a stationary boundary is enough.',
     vrDpad: 'D-pad'
   },
   fr: {
@@ -956,6 +962,9 @@ export const translations = {
     vrGripRight: 'Grip droit',
     vrTriggers: 'Gâchettes',
     vrSticks: 'Un des sticks',
+    vrSeatedHint: 'Se joue assis ou sur place',
+    vrSeatedTitle:
+      'Cette expérience est conçue pour être jouée assis ou sur place : une limite stationnaire suffit.',
     vrDpad: 'Croix'
   }
 };


### PR DESCRIPTION
The last recommendation from the WebXR guidance we looked at, and the only part of the boundary story a page can actually act on.

WebXR gives a page no way to keep a player in their chair, and no way to preselect a boundary type — the Quest's Guardian dialog is the system's own and nothing here reaches it. What is left is to say so, which is the one thing that does work.

> **Enter VR** · Played seated or standing still

**Beside the button rather than under it.** The bar is a centred flex row and a second line would change its height on every page. Only rendered where the VR button is, so a PC with no headset never sees it, and hidden under 640px, where the bar is tight and this is the only thing in it that is advice rather than function.

**The actionable half lives in the button's `title`**, where there is room for a sentence: *"This experience is designed to be played seated or standing still, so a stationary boundary is enough."* Deliberately without quoting the Quest dialog's own wording — that changes between OS versions, and an instruction that goes stale is worse than durable advice.

## Verification

- 564 tests pass, 0 failures (unchanged — this adds none, see below)
- `svelte-check`: 0 errors, 15 warnings across 9 files — the unchanged baseline
- `bun run build` succeeds, and the dev container serves the new markup

## Called out rather than buried

**No test covers this.** There is no component-test harness in this project; the suite tests `lib/` modules, not Svelte components. This change is verified by the typecheck and by the module the container serves, and nothing more.

**A latent gap found while verifying it.** `translations` is a plain object literal with no type enforcing parity between `en` and `fr`, and `TranslationKey` derives from the English locale — so a key missing from French would **not** be a type error. It would pass silently and show a French player nothing. Nine keys were added across this branch series and they were only checked by counting occurrences by hand. A locale-parity test is a few lines and would protect all of them; raised separately rather than folded in here.
