### PR TITLE
Keep a ROM the first time it is read from the folder

### DIFF
--- a/core/test/rom-provider.test.ts
+++ b/core/test/rom-provider.test.ts
@@ -263,3 +263,58 @@ test('hasAccess answers from the query alone and never calls requestPermission',
 	assert.equal(await hasAccess(granted.handle), true);
 	assert.equal(granted.wasRequested(), false, 'already granted needs no request either');
 });
+
+/*
+ * Ce que le dossier donne, l'appareil le garde.
+ *
+ * Sans ça, une ROM lue depuis le dossier n'allait que dans le cache de session :
+ * chaque lancement dépendait à nouveau de la permission de lecture du dossier,
+ * qui expire entre deux sessions de navigateur et dont le renouvellement exige
+ * un geste - impossible à obtenir dans un casque, où aucun dialogue natif ne
+ * peut s'afficher. Signalé depuis un vrai Quest 3 : « l'autorisation ne dure
+ * plus, sauf si je l'autorise en lançant le jeu hors VR », parce que hors VR le
+ * joueur désigne le fichier à la main, et un fichier désigné, lui, était gardé.
+ */
+
+test('une ROM lue depuis le dossier est gardée, donc la permission cesse de compter', async () => {
+	const { readAndKeep, useKeptFiles } = await provider();
+	const { memoryKeptFiles } = await import('../../frontend/src/lib/roms/kept-files.js');
+	const kept = memoryKeptFiles();
+	useKeptFiles(kept);
+
+	const bytes = rom(31);
+	const checksum = crc32(normaliseRom(bytes));
+	const got = await readAndKeep({} as FileSystemDirectoryHandle, checksum, async () => bytes);
+
+	assert.deepEqual([...got!], [...bytes]);
+	assert.deepEqual(
+		await kept.checksums(),
+		[checksum],
+		'non gardée, la ROM redemande le dossier à chaque lancement'
+	);
+	useKeptFiles(null);
+});
+
+test('un dossier qui ne contient pas la ROM ne garde rien', async () => {
+	const { readAndKeep, useKeptFiles } = await provider();
+	const { memoryKeptFiles } = await import('../../frontend/src/lib/roms/kept-files.js');
+	const kept = memoryKeptFiles();
+	useKeptFiles(kept);
+
+	assert.equal(await readAndKeep({} as FileSystemDirectoryHandle, 'deadbeef', async () => null), null);
+	assert.deepEqual(await kept.checksums(), [], 'rien à garder, et surtout pas une absence');
+	useKeptFiles(null);
+});
+
+test('un stockage qui refuse ne fait pas échouer le lancement', async () => {
+	// La règle de `keepQuietly` : « garder est un confort, jamais une condition ».
+	// En navigation privée ou sur quota plein, la partie doit démarrer quand même.
+	const { readAndKeep, useKeptFiles } = await provider();
+	useKeptFiles(throwingKeptFiles());
+
+	const bytes = rom(32);
+	const got = await readAndKeep({} as FileSystemDirectoryHandle, crc32(normaliseRom(bytes)), async () => bytes);
+
+	assert.deepEqual([...got!], [...bytes], 'un quota plein a fait perdre la ROM au joueur');
+	useKeptFiles(null);
+});

--- a/frontend/src/lib/roms/provider.ts
+++ b/frontend/src/lib/roms/provider.ts
@@ -88,6 +88,41 @@ export function isCached(checksum: string): boolean {
 }
 
 /**
+ * Reads one ROM out of the folder, and keeps it.
+ *
+ * The keeping is the whole point of this being its own function. Until now a
+ * ROM read from the folder went into the session cache and nowhere else, so
+ * every launch depended on the folder's read permission - which lapses between
+ * browser sessions and needs a gesture to re-grant, a gesture that inside a
+ * headset takes a whole separate dance (`vr/door.ts`). Keeping the bytes the
+ * first time a game actually runs means that game never needs the permission
+ * again, in VR or out of it, because `resolveQuietly` looks in the kept store
+ * before it ever looks at the folder.
+ *
+ * It also finishes something that was only half built: `kept-files.ts`'s header
+ * already says "l'appareil se remplit au fil des parties", and it did not - only
+ * a file the player designated by hand was ever kept. A ROM read from the
+ * player's own folder is theirs by exactly the same argument, and the rule that
+ * header states - what a HOST sends never enters here - is untouched.
+ *
+ * `read` is a parameter with a default for the reason `xr-session.ts` gives
+ * about `navigator`: `readRomByChecksum` needs IndexedDB and a real directory
+ * handle, so without this seam the keeping could not be tested at all, and a
+ * later edit could drop it in silence.
+ */
+export async function readAndKeep(
+	handle: FileSystemDirectoryHandle,
+	checksum: string,
+	read: typeof readRomByChecksum = readRomByChecksum
+): Promise<Uint8Array | null> {
+	const bytes = await read(handle, checksum);
+	if (!bytes) return null;
+	cache.set(checksum, bytes);
+	await keepQuietly(checksum, bytes);
+	return bytes;
+}
+
+/**
  * Options for {@link resolveQuietly}.
  */
 export interface ResolveQuietlyOptions {
@@ -150,9 +185,7 @@ export async function resolveQuietly(
 			options?.requestPermission === false ? await hasAccess(handle) : await ensureAccess(handle);
 		if (!granted) return null;
 
-		const bytes = await readRomByChecksum(handle, checksum);
-		if (bytes) cache.set(checksum, bytes);
-		return bytes;
+		return await readAndKeep(handle, checksum);
 	} catch {
 		// Même raison : un dossier illisible n'est pas trouvé, et l'appelant sait
 		// déjà quoi faire d'un « non ».


### PR DESCRIPTION
Reported from a real Quest 3 after #31:

> l'autorisation d'accès au dossier ne dure plus, sauf si je l'autorise en lançant le jeu hors VR.

The clue was in the exception. **Out of VR the player designates the file by hand — and a designated file was kept.**

## The cause

The only durable path in this module is `keepQuietly` → IndexedDB, and it was only reachable from `designateFile`: the locate-ROM modal, adding a file from the profile, repairing a legacy entry. A ROM read from the player's own **folder** went into the session cache and nowhere else, so every launch depended again on the folder's read permission — which lapses between browser sessions and which Chromium drops once the origin has no tab open.

**So the door added in #28 was not broken, it was insufficient.** It buys a browser permission, and I wrote that it "lasts the whole session". That was true, and sold as though it settled the matter. It settled it until the tab closed.

## The fix

The first successful read from the folder keeps the bytes. Every later launch finds them in the kept store *before the folder is even consulted*, so the permission stops mattering — in VR and out of it.

**This finishes something that was only half built.** `kept-files.ts`'s header already promises *"l'appareil se remplit au fil des parties"* — and it did not. The rule that same header states, that what a **host** sends never enters here, is untouched: a ROM from the player's own folder is theirs by exactly the argument that already justified keeping a designated file.

Storage is bounded by what the player actually plays, and `keepQuietly` already swallows quota failures — *"garder est un confort, jamais une condition"* — so a full disk still starts the game. The storage cost was raised with the project owner and accepted before this was written.

## Why `readAndKeep` is its own function

So the keeping can be tested at all. `readRomByChecksum` needs IndexedDB and a real directory handle, so this branch was previously **untestable** — and an edit could have dropped the keep in silence. The `read` default parameter is the same seam `xr-session.ts` already uses for `navigator`.

## Verification

- 570 tests pass (+3), 0 failures
- `svelte-check`: 0 errors, 15 warnings across 9 files — the unchanged baseline
- `bun run build` succeeds, and the dev container serves the new module
- **The new test is proven to bite:** removing the `keepQuietly` call takes the file from 18 pass to 17 pass and 1 fail

## Residual

If the door should also turn out to be broken — a question left unanswered, and this fix removes the permission from the equation under either reading — one case would remain: the very first launch of a game never read before. That can be seeded by launching it once outside VR.
