### PR TITLE
Make an empty ROM lookup say which of its five failures it was

### DIFF
--- a/core/test/rom-provider.test.ts
+++ b/core/test/rom-provider.test.ts
@@ -318,3 +318,41 @@ test('un stockage qui refuse ne fait pas échouer le lancement', async () => {
 	assert.deepEqual([...got!], [...bytes], 'un quota plein a fait perdre la ROM au joueur');
 	useKeptFiles(null);
 });
+
+/*
+ * Pourquoi la recherche est revenue vide.
+ *
+ * `resolveQuietly` répond `null` pour cinq situations très différentes, et
+ * l'appelant ne pouvait pas les distinguer : dans un casque, la notice disait
+ * « ce fichier n'a pas pu être lu » sans que personne puisse savoir si le
+ * fautif était la permission, le dossier ou le fichier. Une session de test
+ * entière y est passée. Sous Bun, `supportsDirectoryPicker()` est faux, donc
+ * seule la première raison est atteignable ici - les autres vivent derrière un
+ * vrai handle de dossier.
+ */
+
+test('une recherche vide dit pourquoi', async () => {
+	const { resolveQuietly } = await provider();
+	const reasons: string[] = [];
+
+	assert.equal(await resolveQuietly('deadbeef', { onMiss: (r) => reasons.push(r) }), null);
+	assert.deepEqual(reasons, ['no-picker'], 'sans raison, la notice du casque est indéchiffrable');
+});
+
+test('une ROM trouvée ne déclenche aucune raison', async () => {
+	// Une raison signalée sur un succès rendrait la notice mensongère.
+	const { resolveQuietly, remember } = await provider();
+	const bytes = rom(33);
+	const checksum = remember(bytes);
+	const reasons: string[] = [];
+
+	assert.deepEqual([...(await resolveQuietly(checksum, { onMiss: (r) => reasons.push(r) }))!], [...bytes]);
+	assert.deepEqual(reasons, []);
+});
+
+test('le rapport de raison ne change pas ce qui est renvoyé', async () => {
+	// Purement informatif : les quatre appelants à plat n'en passent pas, et
+	// doivent se comporter exactement comme avant.
+	const { resolveQuietly } = await provider();
+	assert.equal(await resolveQuietly('deadbeef'), await resolveQuietly('deadbeef', { onMiss: () => {} }));
+});

--- a/frontend/src/lib/components/VrShell.svelte
+++ b/frontend/src/lib/components/VrShell.svelte
@@ -55,7 +55,7 @@
   import { user } from '$lib/stores/user';
   import { games } from '$lib/stores/games';
   import { deviceLibrary } from '$lib/roms/device-library';
-  import { resolvableHere, resolveQuietly } from '$lib/roms/provider';
+  import { resolvableHere, resolveQuietly, type MissReason } from '$lib/roms/provider';
   import type { PanelMesh } from '$lib/vr/panel-mesh';
   import { loadCore, AudioSink } from '$lib/znet';
   import { createSoloEngine, type SoloEngine } from '$lib/rooms/solo-engine';
@@ -321,9 +321,25 @@
        * native permission dialog would fire and eject the player from the
        * headset to show it - the exact interruption this panel exists to avoid.
        */
-      const rom = await resolveQuietly(game.crc32, { requestPermission: false });
+      /*
+       * The reason is carried onto the panel, not just logged.
+       *
+       * `resolveQuietly` answers null for five different situations and used to
+       * look identical for all five, which cost a whole headset session: the
+       * notice said the file could not be read and nobody could tell whether
+       * the permission, the folder, or the file itself was the problem. There
+       * is no console in here and the shipped logs are not readable from the
+       * headset either, so the panel is the only channel that reaches the
+       * person who can see the failure.
+       */
+      let miss: MissReason | null = null;
+      const rom = await resolveQuietly(game.crc32, {
+        requestPermission: false,
+        onMiss: (reason) => { miss = reason; }
+      });
       if (!rom) {
-        launchNotice = t($language, 'vrRomUnreadable');
+        launchNotice = `${t($language, 'vrRomUnreadable')} [${miss ?? 'unknown'}]`;
+        logger.error('vr rom miss', { crc32: game.crc32, reason: miss });
         repaintLibrary();
         return;
       }

--- a/frontend/src/lib/roms/provider.ts
+++ b/frontend/src/lib/roms/provider.ts
@@ -123,9 +123,38 @@ export async function readAndKeep(
 }
 
 /**
+ * Why a lookup came up empty.
+ *
+ * `resolveQuietly` answers `null` for five quite different situations, and the
+ * caller could not tell them apart - which is how a headset ended up showing
+ * "that file could not be read" for a failure nobody could locate. These are
+ * codes rather than sentences on purpose: the flat pages have a modal that can
+ * ask for the file, so only the VR panel needs to explain itself, and the
+ * wording belongs there.
+ */
+export type MissReason =
+	/** This browser has no directory picker, and nothing was kept. */
+	| 'no-picker'
+	/** No folder has ever been chosen on this device. */
+	| 'no-folder'
+	/** A folder is stored, but its read permission is not granted right now. */
+	| 'no-permission'
+	/** Permission is fine; neither the remembered name nor a full scan found it. */
+	| 'not-in-folder'
+	/** The folder itself threw - locked database, revoked handle, unreadable disk. */
+	| 'folder-error';
+
+/**
  * Options for {@link resolveQuietly}.
  */
 export interface ResolveQuietlyOptions {
+	/**
+	 * Told which of the five empty answers this was.
+	 *
+	 * Informational only - it never changes what is returned, and a caller that
+	 * omits it behaves exactly as before.
+	 */
+	onMiss?: (reason: MissReason) => void;
 	/**
 	 * Whether a lapsed folder permission may be re-requested.
 	 *
@@ -169,11 +198,17 @@ export async function resolveQuietly(
 		}
 	}
 
-	if (!supportsDirectoryPicker()) return null;
+	if (!supportsDirectoryPicker()) {
+		options?.onMiss?.('no-picker');
+		return null;
+	}
 
 	try {
 		const handle = await storedDirectory();
-		if (!handle) return null;
+		if (!handle) {
+			options?.onMiss?.('no-folder');
+			return null;
+		}
 
 		// Permission on a stored folder lapses between sessions. Whether it is
 		// worth re-requesting is not this function's call to make - it is the
@@ -183,10 +218,16 @@ export async function resolveQuietly(
 		// it to show the prompt on).
 		const granted =
 			options?.requestPermission === false ? await hasAccess(handle) : await ensureAccess(handle);
-		if (!granted) return null;
+		if (!granted) {
+			options?.onMiss?.('no-permission');
+			return null;
+		}
 
-		return await readAndKeep(handle, checksum);
+		const bytes = await readAndKeep(handle, checksum);
+		if (!bytes) options?.onMiss?.('not-in-folder');
+		return bytes;
 	} catch {
+		options?.onMiss?.('folder-error');
 		// Même raison : un dossier illisible n'est pas trouvé, et l'appelant sait
 		// déjà quoi faire d'un « non ».
 		return null;


### PR DESCRIPTION
**This is a diagnostic, not a fix.** Two fixes were built today on inferences about this same failure — the entry door in #28, and keeping folder ROMs in #32 — and the report after each was the same. Measuring first is the correction.

## The problem with the report

A headset session ended like this:

> je clique sur VR / j'autorise l'accès au dossier / je reclique sur VR / j'arrive dans le salon VR / je clique sur mon jeu / il ne se lance pas, à cause de l'accès au dossier

The notice read *"that file could not be read"* — which is what `resolveQuietly`'s `null` looks like for **five quite different situations**:

| code | meaning | verdict on the entry door |
|---|---|---|
| `no-picker` | this browser has no directory picker | door irrelevant |
| `no-folder` | no folder ever chosen **on this device** | door irrelevant |
| `no-permission` | folder stored, permission not granted right now | door failed |
| `not-in-folder` | permission fine, neither the remembered name nor a full scan found it | door worked |
| `folder-error` | the folder itself threw | inconclusive |

Three of the five clear the door of any blame. Two convict it. Nobody — the player in the headset, or me reading the report — could tell which, and that is what made the session unreadable.

## What changes

The reason travels, via an `onMiss` callback. **Informational only:** it never changes what is returned, and a caller that omits it behaves exactly as before — which is all four flat call sites.

**It lands on the panel, not only in the log.** There is no console in an immersive session, and the logs the client ships are not readable from the headset either. The panel is the only channel that reaches the one person who can watch the failure happen. The code appears in brackets after the existing sentence; the wording can become human once we know which one it is.

## Verification

- 573 tests pass (+3), 0 failures
- `svelte-check`: 0 errors, 15 warnings across 9 files — the unchanged baseline
- `bun run build` succeeds
- **Proven to bite:** dropping the `no-picker` report takes the file from 21 pass to 20 pass and 1 fail

Under Bun only `no-picker` is reachable, since `supportsDirectoryPicker` is false with no `window`; the other four live behind a real directory handle and cannot be exercised here. Stated rather than papered over.

## A hypothesis, held behind the measurement

`no-picker`. Quest Browser is Android Chromium, and `showDirectoryPicker` does not exist on Chrome for Android. If that is the answer, the headset never had a folder at all, and the permission granted at the door was for something that was never going to be consulted. But three inferences about this failure were wrong today, so this one waits for the panel to speak.
