### PR TITLE
Stop the VR preparation locking the door it was meant to open

### DIFF
--- a/core/test/vr-prepare.test.ts
+++ b/core/test/vr-prepare.test.ts
@@ -34,6 +34,9 @@ const HANDLE = {} as FileSystemDirectoryHandle;
 function ports(over: Partial<PreparePorts> = {}): PreparePorts {
 	return {
 		keptChecksums: async () => [],
+		// The fixture's whole universe: every checksum these tests name is in
+		// this device's folder unless a test says otherwise.
+		folderChecksums: async () => ['aaa', 'bbb', 'ccc', 'ddd'],
 		storedDirectory: async () => HANDLE,
 		readAndKeep: async () => new Uint8Array([1]),
 		...over
@@ -118,4 +121,33 @@ test('progress is reported once per game, including the failures', async () => {
 
 	await prepareForVr(['aaa', 'bbb', 'ccc'], p, (done, total) => steps.push([done, total]));
 	assert.deepEqual(steps, [[1, 3], [2, 3], [3, 3]]);
+});
+
+test('un jeu absent de CE dossier n est pas du travail à faire', async () => {
+	/*
+	 * La bibliothèque vient du serveur et couvre tous les appareils du joueur,
+	 * donc l'essentiel n'est pas dans ce dossier-ci. Les compter faisait de
+	 * chacun un échec permanent - et tant que la préparation gardait la porte,
+	 * un échec permanent était un verrou : les deux messages revenaient à
+	 * chaque pression et la session ne s'ouvrait jamais. Livré comme ça.
+	 */
+	const p = ports({ folderChecksums: async () => ['aaa'] });
+	assert.deepEqual(
+		await missingFromDevice(['aaa', 'surPC', 'surPortable'], p),
+		['aaa'],
+		'seuls les jeux que ce dossier prétend avoir peuvent être préparés'
+	);
+});
+
+test('une bibliothèque entièrement ailleurs ne demande aucune préparation', async () => {
+	// Le cas du casque dont le dossier est vide : rien à faire, et surtout pas
+	// une pression qui ne prépare rien indéfiniment.
+	const p = ports({ folderChecksums: async () => [] });
+	assert.deepEqual(await missingFromDevice(['aaa', 'bbb'], p), []);
+	assert.deepEqual(await prepareForVr(['aaa', 'bbb'], p), { prepared: 0, failed: 0 });
+});
+
+test('un index de dossier illisible ne barre pas la porte', async () => {
+	const p = ports({ folderChecksums: async () => { throw new Error('index illisible'); } });
+	assert.deepEqual(await missingFromDevice(['aaa'], p), []);
 });

--- a/frontend/src/lib/components/TopBar.svelte
+++ b/frontend/src/lib/components/TopBar.svelte
@@ -39,6 +39,7 @@
   } from '$lib/roms/local-library';
   import { readAndKeep } from '$lib/roms/provider';
   import { keptFilesAvailable, indexedDbKeptFiles } from '$lib/roms/kept-files';
+  import { indexedChecksums } from '$lib/roms/local-library';
   import { games } from '$lib/stores/games';
   import { notifications } from '$lib/services/notification';
 
@@ -49,6 +50,7 @@
 
   const PREPARE: PreparePorts = {
     keptChecksums: async () => (keptFilesAvailable() ? indexedDbKeptFiles().checksums() : []),
+    folderChecksums: async () => (supportsDirectoryPicker() ? indexedChecksums() : []),
     storedDirectory,
     readAndKeep
   };
@@ -64,8 +66,19 @@
    * path - nothing to prepare - has to stay synchronous from click to session.
    */
   let needsPrepare = false;
+  /**
+   * Tried once per page, whatever came of it.
+   *
+   * Without this the door locks: a game that cannot be read here keeps
+   * `needsPrepare` true, so every press runs the preparation again and none of
+   * them ever reaches `requestVr()`. Shipped exactly that way, and it is the
+   * bug this guard exists for - the commit that introduced it claimed
+   * "nothing bars the door" while barring it.
+   */
+  let prepareTried = false;
   $: void refreshPrepareNeed(wanted);
   async function refreshPrepareNeed(list: string[]): Promise<void> {
+    if (prepareTried) return;
     needsPrepare = list.length > 0 && (await missingFromDevice(list, PREPARE)).length > 0;
   }
 
@@ -148,7 +161,11 @@
     });
 
     notifications.dismiss(toast);
-    needsPrepare = (await missingFromDevice(wanted, PREPARE)).length > 0;
+    // Unconditionally, and this is the whole point: preparation is a courtesy,
+    // never a precondition. A second press must enter the session even if
+    // nothing could be read.
+    prepareTried = true;
+    needsPrepare = false;
 
     if (result.failed > 0) {
       // Named rather than hidden: these are the games the headset will still

--- a/frontend/src/lib/vr/prepare.ts
+++ b/frontend/src/lib/vr/prepare.ts
@@ -26,6 +26,15 @@
 export interface PreparePorts {
 	/** The checksums already on this device, needing no permission ever again. */
 	keptChecksums(): Promise<string[]>;
+	/**
+	 * What this device's folder claims to hold, from its own index.
+	 *
+	 * The library comes from the server and spans every machine the player
+	 * owns, so most of it is not in THIS folder. Trying anyway made every such
+	 * game a permanent failure - and while preparation gated the door, a
+	 * permanent failure was a lockout.
+	 */
+	folderChecksums(): Promise<string[]>;
 	storedDirectory(): Promise<FileSystemDirectoryHandle | undefined>;
 	/** `roms/provider.ts`'s `readAndKeep`: reads from the folder and keeps it. */
 	readAndKeep(
@@ -59,7 +68,11 @@ export async function missingFromDevice(
 ): Promise<string[]> {
 	try {
 		const kept = new Set(await ports.keptChecksums());
-		return wanted.filter((checksum) => !kept.has(checksum));
+		const folder = new Set(await ports.folderChecksums());
+		// Both conditions matter. Already kept means nothing to do; absent from
+		// this folder means nothing CAN be done, and counting it as work would
+		// leave the player pressing a button that prepares nothing forever.
+		return wanted.filter((checksum) => !kept.has(checksum) && folder.has(checksum));
 	} catch {
 		return [];
 	}


### PR DESCRIPTION
Reported one deploy after #34:

> quand je clique sur le bouton pour entrer en VR, il m'affiche 2 messages (un warn et un succès) systématiquement mais n'entre pas dans le salon VR

Two causes, both mine, both fixed here.

## The wanted list was too wide

`wanted` was the whole **server-side** library, which spans every machine the player owns. A game whose ROM lives on their PC is not in the headset's folder, so `readAndKeep` failed for it — and would fail forever. That is the warning, every time.

Preparation now considers only the intersection: what **this device's** folder claims, from its own index, minus what is already kept. A game that lives elsewhere is not work to be done; it is work that cannot be done, and counting it was the mistake.

## And a permanent failure was a lockout

`needsPrepare` stayed true after a failed run, and the reactive statement that recomputes it set it true again on every library change — so each press re-ran the preparation and **none of them ever reached `requestVr()`**. That is the second message, and the reason the session never opened.

Preparation is now attempted **once per page load, whatever comes of it**, and the next press enters the session even if nothing could be read.

## On shipping this in the first place

#34 listed "nothing bars the door" as one of its three deliberate decisions, and shipped a door barred by the very check that sentence was about. The `prepare.ts` module was faithful to it — every failure there resolves towards entering — but the gate lived in `TopBar.svelte`, which has no test harness in this project, and I had noted that gap in #34's own description without following it anywhere.

Both fixes are kept rather than just the first. Removing the cause stops it happening for the reason it happened; the once-per-page guard means a genuinely unreadable cartridge can never lock somebody out of the feature either.

## Verification

- 585 tests pass (+3), 0 failures
- `svelte-check`: 0 errors, 15 warnings across 9 files — the unchanged baseline
- `bun run build` succeeds
- **Proven to bite:** dropping either half of the new filter — the folder index, or the already-kept check — fails the suite

## Still not covered

The press sequencing in `TopBar.svelte`, which is where both halves of this bug lived. `vr/prepare.ts` is fully tested and was never wrong; the component that calls it is the untested part, and it stays untested. Worth saying plainly, since it is now the second bug to come out of that file.
