### PR TITLE
Prepare from what the folder holds, not from what its index remembers

### DIFF
--- a/core/test/vr-prepare.test.ts
+++ b/core/test/vr-prepare.test.ts
@@ -37,6 +37,7 @@ function ports(over: Partial<PreparePorts> = {}): PreparePorts {
 		// The fixture's whole universe: every checksum these tests name is in
 		// this device's folder unless a test says otherwise.
 		folderChecksums: async () => ['aaa', 'bbb', 'ccc', 'ddd'],
+		scanFolder: async () => ['aaa', 'bbb', 'ccc', 'ddd'],
 		storedDirectory: async () => HANDLE,
 		readAndKeep: async () => new Uint8Array([1]),
 		...over
@@ -55,17 +56,43 @@ test('a device that cannot say what it holds does not bar the door', async () =>
 	assert.deepEqual(await missingFromDevice(['aaa'], p), []);
 });
 
-test('nothing missing means the folder is never touched', async () => {
-	// The press that finds nothing to do has to stay fast: it is the common
-	// case, and the activation `requestSession` needs is spent by waiting.
-	let asked = false;
+test('a game already on the device is not read again', async () => {
+	let read = 0;
 	const p = ports({
 		keptChecksums: async () => ['aaa'],
-		storedDirectory: async () => { asked = true; return HANDLE; }
+		readAndKeep: async () => { read++; return new Uint8Array([1]); }
 	});
 
 	assert.deepEqual(await prepareForVr(['aaa'], p), { prepared: 0, failed: 0 });
-	assert.equal(asked, false, 'the folder was opened for a device that needed nothing');
+	assert.equal(read, 0, 'a kept ROM needs no folder at all');
+});
+
+test('the scan decides what is attempted, never the index', async () => {
+	/*
+	 * The bug this pins. A headset reported "11/11 games could not be read"
+	 * over a folder holding six: the index still described an older folder,
+	 * every entry missed, and the warning counted them all. Anything the
+	 * folder does not hold is not work that failed - it is work that was
+	 * never possible.
+	 */
+	const read: string[] = [];
+	const p = ports({
+		folderChecksums: async () => ['stale1', 'stale2', 'aaa'],
+		scanFolder: async () => ['aaa'],
+		readAndKeep: async (_h, checksum) => { read.push(checksum); return new Uint8Array([1]); }
+	});
+
+	assert.deepEqual(
+		await prepareForVr(['stale1', 'stale2', 'aaa'], p),
+		{ prepared: 1, failed: 0 },
+		'the two the folder does not hold must not be counted as failures'
+	);
+	assert.deepEqual(read, ['aaa']);
+});
+
+test('a folder that cannot be scanned is a no-op, not a failure', async () => {
+	const p = ports({ scanFolder: async () => { throw new Error('permission gone'); } });
+	assert.deepEqual(await prepareForVr(['aaa'], p), { prepared: 0, failed: 0 });
 });
 
 test('every missing game is read and kept', async () => {
@@ -141,8 +168,10 @@ test('un jeu absent de CE dossier n est pas du travail à faire', async () => {
 
 test('une bibliothèque entièrement ailleurs ne demande aucune préparation', async () => {
 	// Le cas du casque dont le dossier est vide : rien à faire, et surtout pas
-	// une pression qui ne prépare rien indéfiniment.
-	const p = ports({ folderChecksums: async () => [] });
+	// une pression qui ne prépare rien indéfiniment. Les deux sources doivent
+	// être vides - l'index pour ne pas proposer la pression, le scan pour ne
+	// rien tenter si elle a lieu quand même.
+	const p = ports({ folderChecksums: async () => [], scanFolder: async () => [] });
 	assert.deepEqual(await missingFromDevice(['aaa', 'bbb'], p), []);
 	assert.deepEqual(await prepareForVr(['aaa', 'bbb'], p), { prepared: 0, failed: 0 });
 });

--- a/frontend/src/lib/components/TopBar.svelte
+++ b/frontend/src/lib/components/TopBar.svelte
@@ -39,7 +39,7 @@
   } from '$lib/roms/local-library';
   import { readAndKeep } from '$lib/roms/provider';
   import { keptFilesAvailable, indexedDbKeptFiles } from '$lib/roms/kept-files';
-  import { indexedChecksums } from '$lib/roms/local-library';
+  import { indexedChecksums, scanDirectory } from '$lib/roms/local-library';
   import { games } from '$lib/stores/games';
   import { notifications } from '$lib/services/notification';
 
@@ -51,6 +51,7 @@
   const PREPARE: PreparePorts = {
     keptChecksums: async () => (keptFilesAvailable() ? indexedDbKeptFiles().checksums() : []),
     folderChecksums: async () => (supportsDirectoryPicker() ? indexedChecksums() : []),
+    scanFolder: async (handle) => (await scanDirectory(handle)).map((entry) => entry.checksum),
     storedDirectory,
     readAndKeep
   };

--- a/frontend/src/lib/vr/prepare.ts
+++ b/frontend/src/lib/vr/prepare.ts
@@ -27,14 +27,24 @@ export interface PreparePorts {
 	/** The checksums already on this device, needing no permission ever again. */
 	keptChecksums(): Promise<string[]>;
 	/**
-	 * What this device's folder claims to hold, from its own index.
+	 * What the folder's INDEX claims, which is a cache of an older scan.
 	 *
-	 * The library comes from the server and spans every machine the player
-	 * owns, so most of it is not in THIS folder. Trying anyway made every such
-	 * game a permanent failure - and while preparation gated the door, a
-	 * permanent failure was a lockout.
+	 * Cheap, and only ever used to decide whether to offer a preparation press
+	 * - `missingFromDevice` runs on every library change and must not read the
+	 * disk. Being wrong here costs one wasted press, which is why the guess is
+	 * allowed to be stale.
 	 */
 	folderChecksums(): Promise<string[]>;
+	/**
+	 * What is in the folder RIGHT NOW, read and hashed.
+	 *
+	 * The index cannot be trusted for the work itself. A headset reported
+	 * "11/11 games could not be read" over a folder holding six: the index
+	 * described a folder that was no longer there, every one of its entries
+	 * missed, and the warning counted them all. `scanDirectory` computes each
+	 * checksum from the bytes, so it cannot describe a file that is not there.
+	 */
+	scanFolder(handle: FileSystemDirectoryHandle): Promise<string[]>;
 	storedDirectory(): Promise<FileSystemDirectoryHandle | undefined>;
 	/** `roms/provider.ts`'s `readAndKeep`: reads from the folder and keeps it. */
 	readAndKeep(
@@ -91,9 +101,6 @@ export async function prepareForVr(
 	ports: PreparePorts,
 	onProgress?: (done: number, total: number) => void
 ): Promise<PrepareResult> {
-	const missing = await missingFromDevice(wanted, ports);
-	if (missing.length === 0) return { prepared: 0, failed: 0 };
-
 	let handle: FileSystemDirectoryHandle | undefined;
 	try {
 		handle = await ports.storedDirectory();
@@ -103,6 +110,26 @@ export async function prepareForVr(
 	// No folder is not a failure of this device, it is the ordinary state of one
 	// that keeps its games another way. Nothing to read, nothing to report.
 	if (!handle) return { prepared: 0, failed: 0 };
+
+	/*
+	 * The scan, not the index, decides what is attempted.
+	 *
+	 * Anything the folder does not actually hold is not work that failed - it
+	 * is work that was never possible, and counting it produced a warning about
+	 * eleven unreadable games over a folder of six. A game whose ROM lives on
+	 * the player's other machine belongs to that machine.
+	 */
+	let missing: string[];
+	try {
+		const present = new Set(await ports.scanFolder(handle));
+		const kept = new Set(await ports.keptChecksums());
+		missing = wanted.filter((checksum) => present.has(checksum) && !kept.has(checksum));
+	} catch {
+		// A folder that cannot be scanned yields nothing, and says so as a
+		// no-op rather than as a failure the player is asked to act on.
+		return { prepared: 0, failed: 0 };
+	}
+	if (missing.length === 0) return { prepared: 0, failed: 0 };
 
 	let prepared = 0;
 	let failed = 0;


### PR DESCRIPTION
Reported from the headset after #35:

> le warning me parle de 11/11 jeux qui n'ont pas pu être lus alors que je n'ai que 7 fichiers dans mon dossier, dont seulement 6 sont reconnus comme des jeux

**Eleven failures over a folder of six can only mean one thing: the folder was never being looked at.**

## The cause

It was reading the folder's **index** — a cache written by an earlier `scanDirectory` — and that index still described a folder that is no longer there. Every one of its eleven entries missed, and the warning counted them all as the player's unreadable files.

That number is what gave it away. No amount of reasoning about permissions would have: the count itself was the evidence.

## The fix

Preparation now calls `scanDirectory`, which computes each checksum **from the bytes** and therefore cannot describe a file that is not present. What the folder does not hold is no longer a failure — it is work that was never possible, and it belongs to whichever of the player's machines does hold it.

The index is still used, but only to decide whether to **offer** a preparation press: `missingFromDevice` runs on every library change and must not read the disk. Being wrong there costs one wasted press, which is a fair price for not hashing a folder on every store update. Being wrong in the work itself produced a false accusation about the player's own files.

## Verification

- 587 tests pass (+2), 0 failures
- `svelte-check`: 0 errors, 15 warnings across 9 files — the unchanged baseline
- `bun run build` succeeds
- **Proven to bite:** preparing from the index instead of the scan fails the suite, and so does ignoring what the folder contains

## Two things stated rather than buried

**One of the tests updated here failed first, and it was right to.** It overrode only the index while the work had moved to the scan. The fixture was wrong, not the code — worth recording, because "all green first time" would have been a nicer sentence and a false one.

**A cost accepted rather than optimised.** The scan reads and hashes every file, then `readAndKeep` reads them again: twice the bytes. Invisible over six cartridges, noticeable over forty, and not worth solving until it is.
