### PR TITLE
Give the footer a shape, so its fine print stops reading as body copy

### DIFF
--- a/frontend/src/lib/components/SiteFooter.svelte
+++ b/frontend/src/lib/components/SiteFooter.svelte
@@ -13,57 +13,131 @@
    * n'était affiché nulle part : une phrase écrite, traduite, et jamais lue.
    * C'est ici qu'elle vit maintenant, avec le lien vers la page qui la
    * développe.
+   *
+   * La mise en page tient en deux étages, et c'est délibéré : une ligne de
+   * pied de page - la marque à gauche, la navigation à droite - puis l'avis
+   * en dessous. Avant, l'avis était seul : quatre lignes de gris alignées à
+   * gauche sous un accueil entièrement centré, ce qui donnait au bloc l'air
+   * d'un collage. La ligne du haut tient les deux bords, donc le bloc est
+   * ancré, et l'avis n'est plus la seule chose à lire ici.
    */
   import { language } from '$lib/stores/language';
   import { t } from '$lib/i18n/translations';
 </script>
 
 <footer class="site-footer">
-  <nav>
-    <a href="/docs">{t($language, 'documentation')}</a>
-  </nav>
-  <p>{t($language, 'legalText')}</p>
+  <div class="bar">
+    <span class="wordmark">psnes</span>
+    <nav>
+      <a href="/docs">{t($language, 'documentation')}</a>
+    </nav>
+  </div>
+  <p class="notice">{t($language, 'legalText')}</p>
 </footer>
 
 <style>
   .site-footer {
-    /* Bornée et centrée comme le reste des colonnes de texte du site : une
-       phrase de quatre lignes sur toute la largeur d'un écran 27 pouces ne se
-       lit pas. */
+    /* Bornée et centrée comme le reste des colonnes de texte du site - c'est
+       la largeur de `/docs`, la page où ce lien mène : une phrase de quatre
+       lignes sur toute la largeur d'un écran 27 pouces ne se lit pas. */
     width: 100%;
     max-width: 60rem;
     margin: 0 auto;
-    padding: 2rem 1.5rem 2.5rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.07);
+    padding: 0 1.5rem 3rem;
+  }
+
+  /* Le filet, en dégradé qui s'éteint aux deux bouts plutôt qu'en trait net.
+     Un trait franc de 60rem sous une colonne centrée de 600px fait se
+     rencontrer deux largeurs sans rapport ; en s'effaçant, il sépare sans
+     annoncer une largeur. Un ::before plutôt qu'un border-top pour la même
+     raison qu'il porte sa marge : il vit dans le flux, donc l'espace
+     au-dessus et en dessous se règle ici, en un seul endroit. */
+  .site-footer::before {
+    content: '';
+    display: block;
+    height: 1px;
+    margin: 0 0 1.75rem;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(255, 255, 255, 0.13) 15%,
+      rgba(255, 255, 255, 0.13) 85%,
+      transparent
+    );
+  }
+
+  .bar {
     display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.25rem;
+  }
+
+  .wordmark {
+    /* Le dégradé du titre de l'accueil et de celui de `/docs`, en petit : ce
+       qui signe le bas de page appartient à la même famille que ce qui signe
+       le haut. */
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
   }
 
   nav {
     display: flex;
-    gap: 1.25rem;
+    gap: 0.5rem;
     flex-wrap: wrap;
   }
 
+  /* La pastille du sommaire de `/docs`, à l'identique. C'était un lien bleu
+     souligné au survol, la seule occurrence de ce style sur le site. */
   a {
-    color: #8fa4ff;
+    padding: 0.35rem 0.85rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    color: #c8c8d0;
     text-decoration: none;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
+    transition: border-color 0.15s, background 0.15s, color 0.15s;
   }
 
   a:hover,
   a:focus-visible {
-    text-decoration: underline;
+    border-color: rgba(102, 126, 234, 0.8);
+    background: rgba(102, 126, 234, 0.12);
+    color: #fff;
   }
 
-  p {
-    margin: 0;
-    /* Plus discret que le corps de texte, sans descendre au gris qui ne se
-       lit plus : c'est un avis, il doit rester lisible. */
+  .notice {
+    margin: 1.5rem 0 0;
+    /* Le filet à gauche dit « petite ligne » sans rien retirer à la lecture.
+       La taille et la couleur ne bougent pas d'un cheveu par rapport à
+       avant : c'est un avis légal, il doit rester lisible, donc il est
+       rétrogradé par sa place et son cadre, jamais en le rendant plus pâle
+       ou plus petit. */
+    padding-left: 0.9rem;
+    border-left: 2px solid rgba(102, 126, 234, 0.3);
     color: #8a8a96;
     font-size: 0.85rem;
     line-height: 1.6;
     max-width: 46rem;
+  }
+
+  @media (max-width: 40rem) {
+    .site-footer {
+      padding: 0 1rem 2.5rem;
+    }
+
+    .bar {
+      /* La marque et le lien l'un sous l'autre : à deux bords si proches,
+         `space-between` ne tient plus rien, il écarte juste deux objets de
+         quelques pixels. */
+      align-items: flex-start;
+      flex-direction: column;
+    }
   }
 </style>


### PR DESCRIPTION
The footer held one naked blue link and four lines of grey legalese, left aligned under a landing page whose every other element is centred. The notice was the largest thing there and the last thing anyone read — it is fine print, and it looked like body copy pasted in and forgotten.

<!-- before-and-after:start -->
| Before (Desktop) | After (Desktop) |
|:---:|:---:|
| ![Before](https://github.com/pleymor/psnes-online/raw/refs/heads/assets/footer-before-after/captures/footer-before.png) | ![After](https://github.com/pleymor/psnes-online/raw/refs/heads/assets/footer-before-after/captures/footer-after.png) |

| Before (Mobile) | After (Mobile) |
|:---:|:---:|
| ![Before](https://github.com/pleymor/psnes-online/raw/refs/heads/assets/footer-before-after/captures/footer-mobile-before.png) | ![After](https://github.com/pleymor/psnes-online/raw/refs/heads/assets/footer-before-after/captures/footer-mobile-after.png) |

<!-- before-and-after:end -->

## Changes

- **Two storeys.** A footer bar — the wordmark on one edge, the navigation on the other — holds both sides of the column, so the block is anchored rather than hugging the left. The notice sits under it, no longer the only thing to read.
- **The link is the `/docs` table-of-contents pill**, character for character. A bare underlined blue link was the only one of its kind on the site.
- **The rule fades out at both ends** instead of drawing a hard 60rem line under a 600px column — two widths that have nothing to say to each other.
- **The notice keeps its size and its colour to the pixel.** It is a legal notice and the note on it already said it has to stay readable, so it is demoted by where it sits and by the rule down its left side, never by being made paler or smaller.
- **Under 40rem the bar stacks**: at two edges that close, `space-between` holds nothing.

No string moved and no translation key was added, so `i18n-parity` is untouched.

## Testing

- `vite build` in `frontend/` — passes. No test references `SiteFooter`.
- Rendered at 1280px and 390px, in French and in English, against the real landing page on a dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
