### PR TITLE
Send the ROM to whoever lacks it, not only to the guest

### DIFF
--- a/backend/src/websocket/rom-transfer.ts
+++ b/backend/src/websocket/rom-transfer.ts
@@ -6,18 +6,32 @@ import { getMemberRoom } from './guards.js';
 const logger = createLogger('RomTransfer');
 
 /**
- * Hands a room's ROM from the host to a guest who does not have it.
+ * Hands a room's ROM to whichever player does not have it.
  *
- * ROMs live on players' machines now, which leaves the guest who joins a room
- * for a cartridge they do not own. Asking them to go and find a file they may
- * not have is the end of the session, so the host - who by definition has it
- * loaded - sends it across instead.
+ * ROMs live on players' machines now, which leaves whoever joins a room for a
+ * cartridge they have no local copy of. Asking them to go and find a file they
+ * may not have is the end of the session, so the other player sends it across
+ * instead.
  *
- * The server's part is deliberately small: it checks that both ends are in the
- * room, then forwards chunks between them. It does not assemble them, does not
- * hold them, and never writes one down. That is the whole point of the change
- * this exists to support - a chunk is in memory only for as long as it takes to
- * pass it on.
+ * This used to run one way only, host to guest, on the premise that the host
+ * "by definition" holds the cartridge. That premise is false, and production
+ * showed it on 2026-09-09: a library entry lives on the server while the bytes
+ * live on one device, so a host playing from a second machine - or from a
+ * browser whose storage was cleared - is the one without the file. Their
+ * requests were dropped here, three times over two minutes, while the guest sat
+ * holding the dump. Direction is now decided by who is missing what.
+ *
+ * What replaces "only the host may send" is "only to someone who asked". That
+ * is the guard that was actually wanted: being in a room is not consent to
+ * receive four megabytes, and having asked is. It is tracked per room in a
+ * WeakMap, so an unanswered request costs nothing and is collected with the
+ * room rather than needing a sweep.
+ *
+ * The server's part stays deliberately small: it checks that both ends are in
+ * the room and that the recipient asked, then forwards chunks. It does not
+ * assemble them, does not hold them, and never writes one down. That is the
+ * whole point of the change this exists to support - a chunk is in memory only
+ * for as long as it takes to pass it on.
  */
 
 /** One chunk. Comfortably under the relay's own packet ceiling. */
@@ -39,6 +53,41 @@ interface ChunkMessage {
 	payload: ArrayBuffer | Buffer;
 }
 
+/**
+ * Who is waiting for a ROM, and how far along the answer is.
+ *
+ * Keyed by the room object rather than by its id: the entry then dies with the
+ * room, with no expiry to tune and no sweep to forget to run. A request that is
+ * never answered simply stays open for as long as the room lives, which is the
+ * right answer - the player did ask, and is still waiting.
+ */
+interface Pending {
+	/** How many pieces this transfer says it takes; unknown until the first arrives. */
+	total: number | null;
+	/**
+	 * Which pieces have gone through, by sequence number rather than as a count.
+	 *
+	 * A count would close the transfer too early whenever two answers overlap,
+	 * which they do: both machines boot at once, so the asker repeats itself
+	 * until someone replies and the answerer then serves every copy of the
+	 * question it queued. Four arrivals of two distinct pieces would look like a
+	 * finished four-piece transfer, and the two that never came would leave the
+	 * receiver waiting out its stall timeout for a ROM it can no longer be sent.
+	 */
+	seen: Set<number>;
+}
+
+const awaiting = new WeakMap<Room, Map<string, Pending>>();
+
+function askedFor(room: Room): Map<string, Pending> {
+	let map = awaiting.get(room);
+	if (!map) {
+		map = new Map();
+		awaiting.set(room, map);
+	}
+	return map;
+}
+
 export function registerRomTransferHandlers(
 	socket: Socket,
 	user: User,
@@ -47,35 +96,56 @@ export function registerRomTransferHandlers(
 	getUserSocket: (id: string) => string | undefined
 ) {
 	/**
-	 * A guest asking the host for the cartridge.
+	 * A player asking the rest of the room for the cartridge.
 	 *
-	 * Only the host is asked. Any other member would be a guest too, and just
-	 * as likely to be missing the file.
+	 * Everyone else is asked, which in a two-player room is the one other
+	 * player. Whoever has the file answers; whoever has not says so, and the
+	 * asker falls back to picking the file by hand.
 	 */
 	socket.on('rom:request', (data: { roomId: string }) => {
 		const room = getMemberRoom(rooms, data?.roomId, user.id, 'rom:request');
 		if (!room) return;
 
-		if (room.hostId === user.id) return;
+		const others = room.players
+			.map((p) => p.userId)
+			.filter((id) => id !== user.id)
+			.map((id) => ({ id, socketId: getUserSocket(id) }))
+			.filter((peer): peer is { id: string; socketId: string } => Boolean(peer.socketId));
 
-		const hostSocket = getUserSocket(room.hostId);
-		if (!hostSocket) {
-			socket.emit('rom:unavailable', { roomId: room.id, reason: 'The host is not connected' });
+		if (others.length === 0) {
+			socket.emit('rom:unavailable', {
+				roomId: room.id,
+				reason: 'The other player is not connected'
+			});
 			return;
 		}
 
-		logger.info({ roomId: room.id, from: user.pseudo }, 'Guest asked the host for the ROM');
-		io.to(hostSocket).emit('rom:request', { roomId: room.id, from: user.id });
+		// Recorded before the question goes out, so an answer that comes back in
+		// the same tick is not refused for arriving too promptly.
+		askedFor(room).set(user.id, { total: null, seen: new Set() });
+
+		logger.info({ roomId: room.id, from: user.pseudo }, 'A player asked the room for the ROM');
+		for (const peer of others) {
+			io.to(peer.socketId).emit('rom:request', { roomId: room.id, from: user.id });
+		}
 	});
 
 	socket.on('rom:chunk', (data: ChunkMessage) => {
 		const room = getMemberRoom(rooms, data?.roomId, user.id, 'rom:chunk');
 		if (!room) return;
 
-		// Only the host sends. Otherwise a guest could stream bytes at the other
-		// player under the guise of a transfer they never asked for.
-		if (room.hostId !== user.id) {
-			logger.warn({ roomId: room.id, userId: user.id }, 'Rejected a ROM chunk from a non-host');
+		// The recipient has to be in this room; a room id does not authorise
+		// pushing bytes at an arbitrary account.
+		if (!room.players.some((p) => p.userId === data.to)) return;
+
+		// And they have to have asked. This is what stops one player streaming
+		// at the other under the guise of a transfer nobody wanted.
+		const pending = askedFor(room).get(data.to);
+		if (!pending) {
+			logger.warn(
+				{ roomId: room.id, userId: user.id, to: data.to },
+				'Dropped a ROM chunk nobody asked for'
+			);
 			return;
 		}
 
@@ -96,10 +166,6 @@ export function registerRomTransferHandlers(
 			return;
 		}
 
-		// The recipient has to be in this room; a room id does not authorise
-		// pushing bytes at an arbitrary account.
-		if (!room.players.some((p) => p.userId === data.to)) return;
-
 		const target = getUserSocket(data.to);
 		if (!target) return;
 
@@ -110,16 +176,25 @@ export function registerRomTransferHandlers(
 			byteLength: data.byteLength,
 			payload
 		});
+
+		// Tracked by sequence number rather than by watching for the last one: the
+		// receiver is written to accept pieces in any order, and the relay should
+		// not be the one component that quietly requires them to be in order.
+		pending.total ??= data.total;
+		pending.seen.add(data.seq);
+		if (pending.seen.size >= pending.total) askedFor(room).delete(data.to);
 	});
 
-	/** The host has no copy either, so the guest should stop waiting and ask its player. */
+	/** No copy here either, so the asker should stop waiting and pick the file itself. */
 	socket.on('rom:unavailable', (data: { roomId: string; to: string; reason?: string }) => {
 		const room = getMemberRoom(rooms, data?.roomId, user.id, 'rom:unavailable');
-		if (!room || room.hostId !== user.id) return;
+		if (!room) return;
+		if (!askedFor(room).has(data.to)) return;
 
 		const target = getUserSocket(data.to);
 		if (!target) return;
 
+		askedFor(room).delete(data.to);
 		io.to(target).emit('rom:unavailable', { roomId: room.id, reason: data.reason });
 	});
 }

--- a/backend/test/rom-relay.test.ts
+++ b/backend/test/rom-relay.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Who may send a ROM to whom.
+ *
+ * The relay was written for one direction - host to guest - on the premise
+ * that "the host has the cartridge by definition". That premise is false: a
+ * library entry lives on the server and the bytes live on one device, so
+ * playing from a second machine, or after clearing the browser's storage,
+ * leaves the HOST as the one without the file. Production caught it on
+ * 2026-09-09: the host asked three times over two minutes and the relay threw
+ * every request away, while the guest sat there holding the dump.
+ *
+ * So what these pin down is that the relay carries bytes in whichever
+ * direction they are needed, and that "only to someone who asked" - not "only
+ * from the host" - is what keeps a player from pushing megabytes at the other.
+ */
+
+import { test } from 'bun:test';
+import assert from 'node:assert/strict';
+import type { Server, Socket } from 'socket.io';
+import type { Room, User } from '../src/types/index.js';
+import { registerRomTransferHandlers } from '../src/websocket/rom-transfer.js';
+
+const HOST = 'user-host';
+const GUEST = 'user-guest';
+
+function room(over: Partial<Room> = {}): Room {
+  return {
+    id: 'room-1',
+    hostId: HOST,
+    createdBy: HOST,
+    players: [{ userId: HOST }, { userId: GUEST }],
+    status: 'playing',
+    emulationMode: 'lockstep',
+    ...over
+  } as Room;
+}
+
+/**
+ * The relay's four collaborators, faked.
+ *
+ * `registerRomTransferHandlers` already takes every one of them as an
+ * argument, so nothing here reaches around the code under test: the handlers
+ * are the real ones, and what is recorded is what a real socket would have
+ * been told to send.
+ */
+function relay(rooms: Map<string, Room>) {
+  const handlers = new Map<string, (payload: never) => void>();
+  const delivered: Array<{ to: string; event: string; payload: unknown }> = [];
+
+  const connect = (user: User) => {
+    const mine = new Map<string, (payload: never) => void>();
+    const socket = {
+      on: (event: string, handler: (payload: never) => void) => mine.set(event, handler),
+      emit: (event: string, payload: unknown) =>
+        delivered.push({ to: `socket:${user.id}`, event, payload })
+    } as unknown as Socket;
+
+    const io = {
+      to: (target: string) => ({
+        emit: (event: string, payload: unknown) => delivered.push({ to: target, event, payload })
+      })
+    } as unknown as Server;
+
+    registerRomTransferHandlers(socket, user, io, rooms, (id: string) => `socket:${id}`);
+    for (const [event, handler] of mine) handlers.set(`${user.id}:${event}`, handler);
+  };
+
+  const send = (userId: string, event: string, payload: unknown) => {
+    const handler = handlers.get(`${userId}:${event}`);
+    assert.ok(handler, `no handler registered for ${event}`);
+    handler(payload as never);
+  };
+
+  return { connect, send, delivered };
+}
+
+const asUser = (id: string): User => ({ id, pseudo: id } as User);
+
+const chunk = (over: Record<string, unknown> = {}) => ({
+  roomId: 'room-1',
+  seq: 0,
+  total: 1,
+  byteLength: 4,
+  payload: new ArrayBuffer(4),
+  ...over
+});
+
+test('a guest who lacks the ROM still reaches the host', () => {
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms);
+  wire.connect(asUser(HOST));
+  wire.connect(asUser(GUEST));
+
+  wire.send(GUEST, 'rom:request', { roomId: 'room-1' });
+
+  assert.deepEqual(
+    wire.delivered.filter(d => d.event === 'rom:request').map(d => d.to),
+    [`socket:${HOST}`]
+  );
+});
+
+test('a host who lacks the ROM reaches the guest', () => {
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms);
+  wire.connect(asUser(HOST));
+  wire.connect(asUser(GUEST));
+
+  wire.send(HOST, 'rom:request', { roomId: 'room-1' });
+
+  // The whole bug: this used to be dropped on the floor because the asker
+  // happened to be the host, and the host is not always the one with the file.
+  assert.deepEqual(
+    wire.delivered.filter(d => d.event === 'rom:request').map(d => d.to),
+    [`socket:${GUEST}`]
+  );
+});
+
+test('a request is never handed back to whoever asked', () => {
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms);
+  wire.connect(asUser(GUEST));
+
+  wire.send(GUEST, 'rom:request', { roomId: 'room-1' });
+
+  assert.equal(
+    wire.delivered.some(d => d.event === 'rom:request' && d.to === `socket:${GUEST}`),
+    false
+  );
+});
+
+test('a guest may answer the host that asked', () => {
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms);
+  wire.connect(asUser(HOST));
+  wire.connect(asUser(GUEST));
+  wire.send(HOST, 'rom:request', { roomId: 'room-1' });
+
+  wire.send(GUEST, 'rom:chunk', chunk({ to: HOST }));
+
+  const chunks = wire.delivered.filter(d => d.event === 'rom:chunk');
+  assert.equal(chunks.length, 1, 'the guest holding the dump has to be allowed to send it');
+  assert.equal(chunks[0].to, `socket:${HOST}`);
+});
+
+test('nobody receives bytes they did not ask for', () => {
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms);
+  wire.connect(asUser(HOST));
+  wire.connect(asUser(GUEST));
+
+  wire.send(HOST, 'rom:chunk', chunk({ to: GUEST }));
+
+  // This is the guard that replaces "only the host may send". Being in the
+  // room is not consent to receive four megabytes; having asked is.
+  assert.equal(wire.delivered.filter(d => d.event === 'rom:chunk').length, 0);
+});
+
+test('a member with no copy either can say so, whichever side asked', () => {
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms);
+  wire.connect(asUser(HOST));
+  wire.connect(asUser(GUEST));
+  wire.send(HOST, 'rom:request', { roomId: 'room-1' });
+
+  wire.send(GUEST, 'rom:unavailable', { roomId: 'room-1', to: HOST, reason: 'no copy here' });
+
+  const answers = wire.delivered.filter(d => d.event === 'rom:unavailable');
+  assert.equal(answers.length, 1);
+  assert.equal(answers[0].to, `socket:${HOST}`);
+});
+
+test('an outstanding request does not survive the transfer that answered it', () => {
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms);
+  wire.connect(asUser(HOST));
+  wire.connect(asUser(GUEST));
+  wire.send(HOST, 'rom:request', { roomId: 'room-1' });
+  wire.send(GUEST, 'rom:chunk', chunk({ to: HOST, seq: 0, total: 1 }));
+
+  wire.send(GUEST, 'rom:chunk', chunk({ to: HOST, seq: 0, total: 1 }));
+
+  // Otherwise one request is a standing licence to push bytes for as long as
+  // the room lives.
+  assert.equal(wire.delivered.filter(d => d.event === 'rom:chunk').length, 1);
+});
+
+test('a stranger to the room is refused in both directions', () => {
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms);
+  wire.connect(asUser('outsider'));
+
+  wire.send('outsider', 'rom:request', { roomId: 'room-1' });
+  wire.send('outsider', 'rom:chunk', chunk({ to: HOST }));
+
+  assert.equal(wire.delivered.length, 0);
+});
+
+test('two overlapping answers still deliver every piece', () => {
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms);
+  wire.connect(asUser(HOST));
+  wire.connect(asUser(GUEST));
+  wire.send(HOST, 'rom:request', { roomId: 'room-1' });
+
+  // Both machines boot at once, so the asker repeats itself until someone
+  // answers - and the answerer serves every copy of the question it queued.
+  // Two sends therefore interleave, and counting raw arrivals would close the
+  // transfer at four chunks with two of the four sequences never forwarded.
+  for (const seq of [0, 0, 1, 1, 2, 3]) {
+    wire.send(GUEST, 'rom:chunk', chunk({ to: HOST, seq, total: 4 }));
+  }
+
+  const seqs = wire.delivered
+    .filter(d => d.event === 'rom:chunk')
+    .map(d => (d.payload as { seq: number }).seq);
+  assert.deepEqual([...new Set(seqs)].sort(), [0, 1, 2, 3]);
+});

--- a/core/test/vr-launch-options.test.ts
+++ b/core/test/vr-launch-options.test.ts
@@ -328,7 +328,9 @@ test('a device that can open other games still cannot open this one', () => {
     ...NAMING,
     library: library(),
     crc32: 'aaaa1111',
-    room: room(),
+    // Sans room : personne a qui demander, donc l absence bloque encore et le
+    // test porte bien sur `openable` et pas sur le transfert.
+    room: null,
     me: 'me',
     openable: new Set(['bbbb2222', 'cccc3333'])
   });
@@ -342,7 +344,9 @@ test('a ROM this device cannot read blocks the launch and says so', () => {
     ...NAMING,
     library: library(),
     crc32: 'aaaa1111',
-    room: room(),
+    // Personne dans la room pour l envoyer : c est ce qui rend l absence
+    // bloquante, plutot que le fait de ne pas avoir le fichier.
+    room: null,
     me: 'me',
     openable: new Set<string>()
   });
@@ -393,7 +397,9 @@ test('solo needs no seat', () => {
 
 test('a missing ROM outranks a missing seat', () => {
   // The player can do something about a seat from in here. They cannot do
-  // anything about a ROM that is not on the device, so that is what to say.
+  // anything about a ROM that is not on the device and that nobody can send,
+  // so that is what to say. Bob is offline: were he there the game would be on
+  // its way and the seat would be the only thing left to fix.
   const options = launchOptions({
     ...NAMING,
     library: library(),
@@ -401,7 +407,7 @@ test('a missing ROM outranks a missing seat', () => {
     room: room({
       players: [
         { userId: 'me', pseudo: 'Ada', port: null, isReady: false, online: true },
-        { userId: 'you', pseudo: 'Bob', port: null, isReady: false, online: true }
+        { userId: 'you', pseudo: 'Bob', port: null, isReady: false, online: false }
       ]
     }),
     me: 'me',
@@ -682,7 +688,7 @@ test('un invite sans le ROM peut lancer : l hote va le lui envoyer', () => {
   assert.equal(options!.blocked, null, 'donc plus rien ne bloque le lancement');
 });
 
-test('un hote sans le ROM reste bloque : il n a personne a qui demander', () => {
+test('un hote sans le ROM le recoit de l autre joueur', () => {
   const options = launchOptions({
     ...NAMING,
     library: library(),
@@ -691,8 +697,12 @@ test('un hote sans le ROM reste bloque : il n a personne a qui demander', () => 
     me: 'me',
     openable: new Set<string>()
   });
-  assert.equal(options!.romIncoming, false);
-  assert.equal(options!.blocked, 'rom-missing');
+  // Etre hote ne veut pas dire tenir la cartouche : la fiche est sur le
+  // serveur, les octets sont sur un appareil. Un hote qui joue depuis une
+  // deuxieme machine n avait personne a qui demander, et c est exactement ce
+  // que la prod a montre le 2026-09-09.
+  assert.equal(options!.romIncoming, true);
+  assert.equal(options!.blocked, null);
 });
 
 test('seul dans sa room, personne n envoie rien', () => {

--- a/e2e/rom-transfer.spec.ts
+++ b/e2e/rom-transfer.spec.ts
@@ -9,11 +9,12 @@ import { ChunkAssembler, toChunks, type ChunkMessage } from '../frontend/src/lib
  * Handing a ROM from host to guest, against the running stack.
  *
  * core/test/rom-transfer.test.ts covers the chunking and the checks either
- * side. What only a real deployment answers is whether the relay in between
- * behaves: that it forwards bytes unaltered, that it will not let a guest
- * masquerade as the sender, and that a room id alone does not authorise pushing
- * megabytes at somebody. The last two matter because the transfer is the one
- * path in the app where one player can make another's browser allocate.
+ * side, and backend/test/rom-relay.test.ts covers the routing rules against
+ * fakes. What only a real deployment answers is whether the relay in between
+ * behaves: that it forwards bytes unaltered, that it carries them in whichever
+ * direction they are needed, and that a room id alone does not authorise
+ * pushing megabytes at somebody. The last matters because the transfer is the
+ * one path in the app where one player can make another's browser allocate.
  */
 test.describe('ROM transfer', () => {
 	let hostCookie: string, guestCookie: string;
@@ -86,9 +87,11 @@ test.describe('ROM transfer', () => {
 		guest.emit('room:leave', { roomId: room.id });
 	});
 
-	test('a guest cannot pose as the sender', async () => {
+	test('bytes nobody asked for never arrive', async () => {
 		// Otherwise the room id - which friends and invitations hand out - would
-		// be enough to stream arbitrary volume at the other player.
+		// be enough to stream arbitrary volume at the other player. Being in the
+		// room is not consent to receive four megabytes; having asked is, and
+		// that is the whole of the rule now that either side may be the sender.
 		const room = await roomWithBoth('ROM Transfer Authz');
 		const chunk = toChunks(rom(13, 4096))[0];
 
@@ -101,9 +104,57 @@ test.describe('ROM transfer', () => {
 		guest.emit('room:leave', { roomId: room.id });
 	});
 
+	test('a host without the cartridge is served by its guest', async () => {
+		/*
+		 * The direction the relay refused until 2026-09-09. A library entry is
+		 * on the server and the bytes are on one device, so a host playing from
+		 * a second machine is the one missing the file - and its requests were
+		 * dropped here while the guest sat holding the dump.
+		 */
+		const room = await roomWithBoth('ROM Transfer Upstream');
+		const original = rom(19, 96 * 1024);
+
+		const asked = waitForEvent<{ roomId: string; from: string }>(guest, 'rom:request', 5000);
+		host.emit('rom:request', { roomId: room.id });
+		const request = await asked;
+
+		expect(request?.roomId).toBe(room.id);
+
+		const assembler = new ChunkAssembler();
+		const complete = new Promise<Uint8Array>((resolve, reject) => {
+			host.on('rom:chunk', (message: ChunkMessage) => {
+				const done = assembler.accept({
+					seq: message.seq,
+					total: message.total,
+					byteLength: message.byteLength,
+					payload: message.payload
+				});
+				if (done) resolve(done);
+			});
+			setTimeout(() => reject(new Error('the transfer never completed')), 15_000);
+		});
+
+		for (const chunk of toChunks(original)) {
+			guest.emit('rom:chunk', { ...chunk, roomId: room.id, to: request!.from });
+		}
+
+		const received = await complete;
+		expect(crc32(received)).toBe(crc32(original));
+
+		host.off('rom:chunk');
+		host.emit('room:leave', { roomId: room.id });
+		guest.emit('room:leave', { roomId: room.id });
+	});
+
 	test('an oversized chunk is dropped without breaking the connection', async () => {
 		const room = await roomWithBoth('ROM Transfer Size');
 		const huge = new Uint8Array(200 * 1024);
+
+		// The guest has to have asked before anything can reach it at all, so
+		// the oversized chunk is refused on its size and not on its welcome.
+		const asked = waitForEvent<{ roomId: string; from: string }>(host, 'rom:request', 5000);
+		guest.emit('rom:request', { roomId: room.id });
+		expect(await asked).not.toBeNull();
 
 		const delivered = waitForEvent<unknown>(guest, 'rom:chunk', 1200);
 		host.emit('rom:chunk', {

--- a/frontend/src/lib/components/LockstepRoom.svelte
+++ b/frontend/src/lib/components/LockstepRoom.svelte
@@ -374,9 +374,13 @@
 
   onMount(() => {
     // Registered before the core starts loading, not after. Both machines boot
-    // at once and the guest asks for the ROM straight away; a listener attached
+    // at once and whoever lacks the ROM asks straight away; a listener attached
     // at the end of boot would miss the first requests.
-    if (isHost) $socket?.on('rom:request', onRomRequested);
+    //
+    // On both sides, not just the host's. The host is not the one who
+    // necessarily holds the cartridge - the library entry is on the server and
+    // the bytes are on one device - so either player may be the one asked.
+    $socket?.on('rom:request', onRomRequested);
     $socket?.on('connect', onSocketReconnected);
     $socket?.on('znet:error', onRelayError);
     $socket?.on('player:left', onPlayerLeft);
@@ -1028,31 +1032,31 @@
       return found;
     }
 
-    // The guest asks the host before it asks the player. The host has the
-    // cartridge by definition, and sending someone away to find a file they may
-    // not have is the end of the session.
-    if (!isHost) {
-      try {
-        statusText = 'Receiving the ROM from the host…';
-        const rom = await receiveRom({
-          socket: $socket as never,
-          roomId,
-          expectedCrc32: gameCrc32,
-          onProgress: (done, total) => (romTransfer = { direction: 'in', done, total })
-        });
-        romTransfer = null;
-        // `remember` fait tourner la partie ; les octets meurent avec l'onglet
-        // tant que l'invité n'a pas répondu à la question que voici.
-        remember(rom);
-        keepOffer.received(gameCrc32, rom);
-        logger.info(`Received the ROM from the host (${rom.byteLength} bytes)`, { crc32: gameCrc32 });
-        return rom;
-      } catch (err) {
-        romTransfer = null;
-        // Not fatal: the player may well have the file, so fall through to
-        // asking rather than dropping them back into the lobby.
-        logger.warn('The host could not send the ROM', err);
-      }
+    // Ask the other player before asking this one. Sending someone away to
+    // find a file they may not have is the end of the session, and the peer is
+    // as likely to hold the dump as this machine is: `isHost` used to gate
+    // this, on the premise that a host always has the cartridge, and a host
+    // playing from a second machine was left with nowhere to turn.
+    try {
+      statusText = 'Receiving the ROM from the other player…';
+      const rom = await receiveRom({
+        socket: $socket as never,
+        roomId,
+        expectedCrc32: gameCrc32,
+        onProgress: (done, total) => (romTransfer = { direction: 'in', done, total })
+      });
+      romTransfer = null;
+      // `remember` fait tourner la partie ; les octets meurent avec l'onglet
+      // tant que l'invité n'a pas répondu à la question que voici.
+      remember(rom);
+      keepOffer.received(gameCrc32, rom);
+      logger.info(`Received the ROM from the other player (${rom.byteLength} bytes)`, { crc32: gameCrc32 });
+      return rom;
+    } catch (err) {
+      romTransfer = null;
+      // Not fatal: the player may well have the file, so fall through to
+      // asking rather than dropping them back into the lobby.
+      logger.warn('The other player could not send the ROM', err);
     }
 
     logger.info('No local copy found; asking the player', { crc32: gameCrc32 });
@@ -1066,19 +1070,27 @@
     });
   }
 
+  /** Who is already being served, so a repeated question is not answered twice. */
+  let serving = new Set<string>();
+
   /**
-   * Answers a guest that has no copy of the cartridge.
+   * Answers whichever player has no copy of the cartridge.
    *
    * Sending happens off the frame loop, a chunk at a time: lockstep runs no
-   * faster than its slowest peer, so a host that stutters pushing four
-   * megabytes into a socket stalls the guest it is helping.
+   * faster than its slowest peer, so a machine that stutters pushing four
+   * megabytes into a socket stalls the player it is helping.
+   *
+   * The asker repeats itself every two seconds until the first piece lands, so
+   * two or three copies of the same question are normal at boot. Serving each
+   * of them would push the ROM two or three times over.
    */
   async function onRomRequested(data: { roomId: string; from: string }) {
-    if (data?.roomId !== roomId || !isHost) return;
+    if (data?.roomId !== roomId) return;
+    if (serving.has(data.from)) return;
 
     const rom = loadedRom ?? (gameCrc32 ? await resolveQuietly(gameCrc32) : null);
     if (!rom) {
-      logger.warn('A guest asked for the ROM but this machine has no copy either');
+      logger.warn('A player asked for the ROM but this machine has no copy either');
       $socket?.emit('rom:unavailable', {
         roomId,
         to: data.from,
@@ -1087,17 +1099,22 @@
       return;
     }
 
-    logger.info(`Sending the ROM to a guest (${rom.byteLength} bytes)`);
-    await sendRom({
-      socket: $socket as never,
-      roomId,
-      to: data.from,
-      rom,
-      onProgress: (done, total) => (romTransfer = { direction: 'out', done, total }),
-      // A frame is 16ms; yielding to the macrotask queue between chunks keeps
-      // the emulator's slice from being pushed aside by the transfer.
-      pause: () => new Promise<void>((resolve) => setTimeout(resolve, 0))
-    });
+    logger.info(`Sending the ROM to the other player (${rom.byteLength} bytes)`);
+    serving.add(data.from);
+    try {
+      await sendRom({
+        socket: $socket as never,
+        roomId,
+        to: data.from,
+        rom,
+        onProgress: (done, total) => (romTransfer = { direction: 'out', done, total }),
+        // A frame is 16ms; yielding to the macrotask queue between chunks keeps
+        // the emulator's slice from being pushed aside by the transfer.
+        pause: () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+      });
+    } finally {
+      serving.delete(data.from);
+    }
     romTransfer = null;
     logger.info('Finished sending the ROM');
   }
@@ -1316,13 +1333,13 @@
   <!-- The transfer banner and the ROM prompt live inside .lockstep rather than
        beside it: both are fixed overlays, so their position is unchanged, but
        as descendants of the fullscreen element they still render once a player
-       goes fullscreen. A host serving a ROM to a guest who joins mid-match
+       goes fullscreen. A player serving a ROM to the one who joins mid-match
        would otherwise watch a silent transfer. -->
   {#if romTransfer}
     <div class="rom-transfer">
       <span>
         {romTransfer.direction === 'in'
-          ? 'Receiving the ROM from the host'
+          ? 'Receiving the ROM from the other player'
           : 'Sending the ROM to the other player'}
       </span>
       <progress value={romTransfer.done} max={romTransfer.total}></progress>

--- a/frontend/src/lib/components/P2PRoom.svelte
+++ b/frontend/src/lib/components/P2PRoom.svelte
@@ -125,9 +125,11 @@
     const found = await resolveQuietly(gameCrc32);
     if (found) return found;
 
-    // The guest asks the host before it asks the player: in a room for someone
-    // else's game, the host is the one machine certain to have the cartridge.
-    if (!isHost && emulationMode !== EmulationMode.SINGLE) {
+    // Ask the other player before asking this one. `isHost` used to gate this
+    // too, on the premise that the host is the machine certain to have the
+    // cartridge - it is not: the library entry lives on the server and the
+    // bytes live on one device, so a host on a second machine has none.
+    if (emulationMode !== EmulationMode.SINGLE) {
       try {
         const rom = await receiveRom({
           socket: $socket as never,
@@ -140,11 +142,11 @@
         // tant que l'invité n'a pas répondu à la question que voici.
         remember(rom);
         keepOffer.received(gameCrc32, rom);
-        logger.info(`📦 Received the ROM from the host (${rom.byteLength} bytes)`);
+        logger.info(`📦 Received the ROM from the other player (${rom.byteLength} bytes)`);
         return rom;
       } catch (err) {
         romTransfer = null;
-        logger.warn('The host could not send the ROM', err);
+        logger.warn('The other player could not send the ROM', err);
       }
     }
 
@@ -156,29 +158,38 @@
     });
   }
 
-  /** Answers a guest that has no copy of the cartridge. See LockstepRoom. */
+  /** Who is already being served, so a repeated question is not answered twice. */
+  let serving = new Set<string>();
+
+  /** Answers whichever player has no copy of the cartridge. See LockstepRoom. */
   async function onRomRequested(data: { roomId: string; from: string }) {
-    if (data?.roomId !== roomId || !isHost) return;
+    if (data?.roomId !== roomId) return;
+    if (serving.has(data.from)) return;
 
     const rom = loadedRom ?? (gameCrc32 ? await resolveQuietly(gameCrc32) : null);
     if (!rom) {
       $socket?.emit('rom:unavailable', {
         roomId,
         to: data.from,
-        reason: 'The host does not have this ROM either'
+        reason: 'The other player does not have this ROM either'
       });
       return;
     }
 
-    logger.info(`📦 Sending the ROM to a guest (${rom.byteLength} bytes)`);
-    await sendRom({
-      socket: $socket as never,
-      roomId,
-      to: data.from,
-      rom,
-      onProgress: (done, total) => (romTransfer = { direction: 'out', done, total }),
-      pause: () => new Promise<void>((resolve) => setTimeout(resolve, 0))
-    });
+    logger.info(`📦 Sending the ROM to the other player (${rom.byteLength} bytes)`);
+    serving.add(data.from);
+    try {
+      await sendRom({
+        socket: $socket as never,
+        roomId,
+        to: data.from,
+        rom,
+        onProgress: (done, total) => (romTransfer = { direction: 'out', done, total }),
+        pause: () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+      });
+    } finally {
+      serving.delete(data.from);
+    }
     romTransfer = null;
   }
 
@@ -918,7 +929,8 @@
   onMount(async () => {
     // Before anything else loads: the guest asks for the ROM as soon as it
     // mounts, and a listener attached later would miss the first requests.
-    if (isHost) $socket?.on('rom:request', onRomRequested);
+    // On both sides: either player may be the one without the cartridge.
+    $socket?.on('rom:request', onRomRequested);
 
     // Always add keyboard listener for pause menu (Escape key)
     window.addEventListener('keydown', handleKeyDown);
@@ -1001,7 +1013,7 @@
   <div class="rom-transfer">
     <span>
       {romTransfer.direction === 'in'
-        ? 'Receiving the ROM from the host'
+        ? 'Receiving the ROM from the other player'
         : 'Sending the ROM to the other player'}
     </span>
     <progress value={romTransfer.done} max={romTransfer.total}></progress>

--- a/frontend/src/lib/components/VrShell.svelte
+++ b/frontend/src/lib/components/VrShell.svelte
@@ -296,6 +296,15 @@
    * depuis un casque est « une danse à part entière » (`vr/door.ts`).
    */
   let loadedRom: Uint8Array | null = null;
+
+  /**
+   * Qui est déjà servi, pour ne pas répondre deux fois à la même question.
+   *
+   * Le demandeur répète sa demande toutes les deux secondes jusqu'au premier
+   * morceau, donc deux ou trois exemplaires de la même question sont normaux au
+   * démarrage. Les servir tous enverrait la ROM deux ou trois fois.
+   */
+  const serving = new Set<string>();
   /** The dump whose launch options the screen is showing, or null for the
    * checkerboard. */
   let launchFor: string | null = null;
@@ -2039,7 +2048,7 @@
    * regarde le cache en premier, qui est exactement là où un jeu reçu vit.
    *
    * Rien en main veut dire que le transfert n'a pas eu lieu : la réponse est
-   * alors honorée à la réception, par `receiveFromHost`.
+   * alors honorée à la réception, par `receiveFromPeer`.
    */
   async function keepNow(): Promise<void> {
     const crc32 = launchFor;
@@ -2056,28 +2065,27 @@
   }
 
   /**
-   * Le jeu, reçu de l'hôte, quand cet appareil ne l'a pas.
+   * Le jeu, reçu de l'autre joueur, quand cet appareil ne l'a pas.
    *
    * C'est la moitié qui manquait à la VR. Le serveur relaie `rom:request` et
-   * `rom:chunk` depuis toujours et `LockstepRoom.svelte` s'en sert : un invité
-   * sans cartouche la reçoit de l'hôte, vérifiée contre le CRC32 de la room.
-   * Le shell VR, lui, abandonnait - et disait au joueur de sortir du casque,
-   * ce que deux joueurs ont dû faire pour de vrai le 2026-09-08.
+   * `rom:chunk` depuis toujours et `LockstepRoom.svelte` s'en sert : qui n'a
+   * pas la cartouche la reçoit, vérifiée contre le CRC32 de la room. Le shell
+   * VR, lui, abandonnait - et disait au joueur de sortir du casque, ce que deux
+   * joueurs ont dû faire pour de vrai le 2026-09-08.
    *
-   * L'hôte ne reçoit rien : le serveur route la demande vers SON socket, donc
-   * un hôte sans cartouche n'a personne à qui demander. `launch-options.ts`
-   * tient la même règle pour décider si l'écran de lancement bloque.
+   * L'hôte recevait encore moins que les autres : le relais ne routait une
+   * demande que vers SON socket, donc un hôte sans cartouche n'avait personne
+   * à qui demander. La prod l'a montré le 2026-09-09, l'hôte réclamant trois
+   * fois en deux minutes pendant que l'invité tenait le dump. Le relais route
+   * maintenant vers celui qui ne demande pas, et `launch-options.ts` tient la
+   * même règle pour décider si l'écran de lancement bloque.
    *
    * Rend null plutôt que de lever : l'appelant a déjà un chemin pour « pas de
    * ROM », et c'est le bon - le message qu'il pose est le dernier recours.
    */
-  async function receiveFromHost(
-    roomId: string,
-    crc32: string,
-    isHost: boolean
-  ): Promise<Uint8Array | null> {
+  async function receiveFromPeer(roomId: string, crc32: string): Promise<Uint8Array | null> {
     const sock = $socket;
-    if (isHost || !sock) return null;
+    if (!sock) return null;
 
     try {
       const rom = await receiveRom({
@@ -2122,22 +2130,25 @@
     const sock = $socket;
     const room = $myRoom;
     if (!sock || !data || !room || data.roomId !== room.id) return;
-    if (room.hostId !== $user?.id) return;
+    // Plus de filtre sur l'hôte : c'est l'autre joueur qui demande, quel que
+    // soit son rôle, et ce casque répond s'il tient la cartouche.
+    if (serving.has(data.from)) return;
 
     const crc32 = room.gameCrc32;
     const rom = loadedRom ?? (crc32 ? await resolveQuietly(crc32, { requestPermission: false }) : null);
     if (!rom) {
-      // Dit plutôt que tu : sans ça l'invité attend le timeout de `receiveRom`
+      // Dit plutôt que tu : sans ça l'autre attend le timeout de `receiveRom`
       // devant un écran qui ne dit rien.
-      logger.warn('a guest asked for the ROM but this headset has no copy either');
+      logger.warn('a player asked for the ROM but this headset has no copy either');
       sock.emit('rom:unavailable', {
         roomId: room.id,
         to: data.from,
-        reason: 'The host does not have this ROM either'
+        reason: 'The other player does not have this ROM either'
       });
       return;
     }
 
+    serving.add(data.from);
     try {
       await sendRom({
         socket: sock as never,
@@ -2151,6 +2162,7 @@
         pause: () => new Promise<void>((resolve) => setTimeout(resolve, 0))
       });
     } finally {
+      serving.delete(data.from);
       romTransfer = null;
       repaintLaunch();
     }
@@ -2221,7 +2233,7 @@
       setLogLabels({ roomId, player: isHost ? 'p1' : 'p2' });
 
       const rom = (await resolveQuietly(crc32, { requestPermission: false }))
-        ?? (await receiveFromHost(roomId, crc32, isHost));
+        ?? (await receiveFromPeer(roomId, crc32));
       if (!rom) {
         // The refusal the launch screen already predicted. Saying it twice is
         // better than a black screen.

--- a/frontend/src/lib/vr/launch-options.ts
+++ b/frontend/src/lib/vr/launch-options.ts
@@ -66,11 +66,12 @@ export interface LaunchRoom {
 	/** Who may stage a save. Not the host: the host can change hands. */
 	createdBy: string;
 	/**
-	 * Who serves a missing ROM, and therefore who cannot receive one.
+	 * Whose room this is, for everything that turns on it elsewhere.
 	 *
-	 * The server routes `rom:request` to the host's socket
-	 * (`websocket/rom-transfer.ts`), so this is not a cosmetic distinction from
-	 * `createdBy`: a guest can be sent the cartridge, a host has nobody to ask.
+	 * It used to decide who could be sent a missing ROM as well - the relay
+	 * only ever routed a request to the host - so a host without the cartridge
+	 * had nobody to ask. `websocket/rom-transfer.ts` now routes to whoever is
+	 * NOT asking, and this field has no say in the transfer any more.
 	 */
 	hostId: string;
 	status: 'waiting' | 'playing';
@@ -118,12 +119,12 @@ export interface LaunchOptions {
 	/** Whether this device can read the ROM at all. */
 	romHere: boolean;
 	/**
-	 * The ROM is not here, and the host of this room will send it.
+	 * The ROM is not here, and the other player in this room will send it.
 	 *
 	 * Distinct from `!romHere` because it is what turns a refusal into a wait:
 	 * the screen says the friend is about to send the game instead of telling
-	 * the player to leave the headset. Only ever true for a guest - see
-	 * `LaunchRoom.hostId`.
+	 * the player to leave the headset. True for either side of the room - what
+	 * it needs is somebody to ask, not a particular role.
 	 */
 	romIncoming: boolean;
 	blocked: LaunchBlock | null;
@@ -211,12 +212,20 @@ export function launchOptions(input: LaunchInput): LaunchOptions | null {
 	/*
 	 * Not here, but on its way.
 	 *
-	 * `other !== null` is what makes this a group rather than a lone creator's
-	 * room, and `hostId !== me` is what makes this player the one who can
-	 * receive. Both are needed: a host has nobody to ask, and an empty room has
-	 * nobody to ask either.
+	 * `other !== null` is the whole condition: it is what makes this a group
+	 * rather than a lone creator's room, and so what says there is somebody to
+	 * ask. `hostId !== me` used to be required too, on the belief that a host
+	 * has nobody to ask - false, and it cost a session on 2026-09-09. The
+	 * cartridge is on a device while the library entry is on the server, so a
+	 * host playing from a second machine is the one without the file, and the
+	 * relay now carries a ROM in whichever direction it is needed.
+	 *
+	 * `online` because a promise is what this flag makes: the screen stops
+	 * saying "go and find the file" and says "your friend is sending it". A
+	 * player whose tab is closed sends nothing, and a wait that never ends is
+	 * worse than a refusal that can be acted on.
 	 */
-	const romIncoming = !romHere && other !== null && room !== null && room.hostId !== input.me;
+	const romIncoming = !romHere && other !== null && other.online === true;
 
 	return {
 		game: {
@@ -275,8 +284,8 @@ export function launchOptions(input: LaunchInput): LaunchOptions | null {
  * It used to be the one that could NOT be fixed from in there, which is why
  * the message told the player to leave VR. That was true only because the VR
  * shell had never learned the transfer the flat room has always used, so
- * `romAvailable` now means "here, or on its way from the host" - and a guest
- * is no longer sent out of the headset to fetch what their friend is holding.
+ * `romAvailable` now means "here, or on its way from the other player" - and
+ * nobody is sent out of the headset to fetch what their friend is holding.
  */
 function blockedBy(
 	room: LaunchRoom | null,


### PR DESCRIPTION
Reported after a two-player session: the host was told to go and find the file on disk, and the game would not start. Production says exactly what happened, on 2026-09-09 at 19:35:

```
Pleymor  p1 (host)   8A926D1A  No local copy found; asking the player
fredoche p2 (guest)  8A926D1A  Loaded the ROM from this machine (2097152 bytes)
```

The guest was holding the dump. The host asked three times over two minutes and the relay threw every request away — the transfer only ever ran host → guest. Six minutes earlier the same pair transferred a different game host → guest without trouble, which is what makes the shape clear: **the feature works, its direction does not.**

The premise written all over this code — *"the host has the cartridge by definition"* — is false. The library entry lives on the server and the bytes live on one device, so playing from a second machine, or from a browser whose storage was cleared, leaves the host as the one without the file and with nobody to ask.

## Changes

- **`backend/src/websocket/rom-transfer.ts`** — a request routes to whoever is *not* asking, rather than to the host. `only to someone who asked` replaces `only from the host`: being in a room is not consent to receive four megabytes, having asked is. Kept per room in a `WeakMap` keyed by the room object, so an unanswered request costs nothing and is collected with the room instead of needing a sweep.
- **`LockstepRoom` / `P2PRoom` / `VrShell`** — both sides ask, both sides answer, and each serves one transfer per asker rather than one per question.
- **`vr/launch-options.ts`** — `romIncoming` no longer depends on the role, but now requires the other player to be **online**: the flag turns a refusal into a promise on screen, and a promise about a closed tab is a wait that never ends.

Two things the tests caught that the fix would otherwise have broken:

1. Counting raw chunk arrivals closes a transfer too early whenever two answers overlap — and they do, since the asker repeats every two seconds until the first piece lands and the answerer serves every queued copy. Four arrivals of two distinct pieces looked like a finished four-piece transfer. Arrivals are tracked by sequence number now.
2. `romIncoming` for an offline peer promised a transfer that could never start.

## Testing

- `backend/test/rom-relay.test.ts` — new, 10 tests, written failing first; 5 failed for the right reasons before the fix.
- `bun run test:all` — 130 + 20 + 913 + 359, exit 0.
- `svelte-check` 0 errors; backend `tsc --noEmit` clean; `vite build` clean.
- **Against a running stack** (backend :3100, frontend :5273, throwaway redis): all five `e2e/rom-transfer.spec.ts` specs pass, including the new *"a host without the cartridge is served by its guest"* — the reported bug, end to end.

Not from this branch: the full e2e run has 4 failures (`app.spec`, `identify-game-ui` ×2, `resume-from-save`). The same 4 fail on `main` with these changes stashed. Untouched here, and unexamined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
