### PR TITLE
Make an offer that goes nowhere say so

### DIFF
--- a/backend/src/websocket/rom-transfer.ts
+++ b/backend/src/websocket/rom-transfer.ts
@@ -164,8 +164,28 @@ export function registerRomTransferHandlers(
 		if (!room) return;
 		if (typeof data.crc32 !== 'string' || !data.crc32) return;
 
-		logger.info({ roomId: room.id, from: user.pseudo, crc32: data.crc32 }, 'A player offered a game');
-		for (const peer of othersInRoom(room, user.id, getUserSocket)) {
+		const others = othersInRoom(room, user.id, getUserSocket);
+
+		/*
+		 * Personne à qui offrir, et il faut le dire.
+		 *
+		 * L'autre joueur a fermé son onglet, ou n'a jamais eu de socket. Sans
+		 * cette réponse le bouton de l'offrant attend indéfiniment - et le
+		 * journal disait « offered a game » comme si tout allait bien, parce
+		 * qu'il était écrit AVANT de savoir si quelqu'un avait été atteint.
+		 * C'est ce silence qui a rendu indécidable, le 2026-09-10, un « l'ami
+		 * ne voit jamais de message ».
+		 */
+		if (others.length === 0) {
+			logger.warn(
+				{ roomId: room.id, from: user.pseudo, crc32: data.crc32 },
+				'A player offered a game but nobody in the room was reachable'
+			);
+			socket.emit('rom:offer-declined', { roomId: room.id, reason: 'unreachable' });
+			return;
+		}
+
+		for (const peer of others) {
 			io.to(peer.socketId).emit('rom:offer', {
 				roomId: room.id,
 				crc32: data.crc32,
@@ -173,6 +193,12 @@ export function registerRomTransferHandlers(
 				from: user.id
 			});
 		}
+		// Après coup, et avec le compte : « transmis à un joueur » et « jeté
+		// dans le vide » ne doivent pas se lire pareil dans le journal.
+		logger.info(
+			{ roomId: room.id, from: user.pseudo, crc32: data.crc32, to: others.length },
+			'A player offered a game'
+		);
 	});
 
 	/** "No thanks", so the offering side stops waiting on an answer. */

--- a/backend/test/rom-relay.test.ts
+++ b/backend/test/rom-relay.test.ts
@@ -43,7 +43,11 @@ function room(over: Partial<Room> = {}): Room {
  * are the real ones, and what is recorded is what a real socket would have
  * been told to send.
  */
-function relay(rooms: Map<string, Room>) {
+function relay(
+  rooms: Map<string, Room>,
+  /** Qui est joignable. Par défaut tout le monde ; un onglet fermé n'a plus de socket. */
+  getUserSocket: (id: string) => string | undefined = (id) => `socket:${id}`
+) {
   const handlers = new Map<string, (payload: never) => void>();
   const delivered: Array<{ to: string; event: string; payload: unknown }> = [];
 
@@ -61,7 +65,7 @@ function relay(rooms: Map<string, Room>) {
       })
     } as unknown as Server;
 
-    registerRomTransferHandlers(socket, user, io, rooms, (id: string) => `socket:${id}`);
+    registerRomTransferHandlers(socket, user, io, rooms, getUserSocket);
     for (const [event, handler] of mine) handlers.set(`${user.id}:${event}`, handler);
   };
 
@@ -316,4 +320,22 @@ test('un refus ne s adresse qu a un membre du salon', () => {
   wire.send(GUEST, 'rom:offer-declined', { roomId: 'room-1', to: 'outsider' });
 
   assert.equal(wire.delivered.length, 0);
+});
+
+test('une offre que personne ne peut recevoir le dit a celui qui l a faite', () => {
+  // Le seul membre joignable est l offrant : l autre a ferme son onglet, ou
+  // n a jamais eu de socket. Sans reponse, son bouton attend pour toujours -
+  // et le journal disait « offered a game » comme si tout allait bien, parce
+  // qu il etait ecrit AVANT de savoir si quelqu un avait ete atteint.
+  const rooms = new Map([['room-1', room()]]);
+  const wire = relay(rooms, (id) => (id === HOST ? `socket:${HOST}` : undefined));
+  wire.connect(asUser(HOST));
+
+  wire.send(HOST, 'rom:offer', { roomId: 'room-1', crc32: 'DEADBEEF', title: 'X' });
+
+  const answers = wire.delivered.filter(d => d.event === 'rom:offer-declined');
+  assert.equal(answers.length, 1);
+  assert.equal(answers[0].to, `socket:${HOST}`);
+  assert.equal((answers[0].payload as { reason: string }).reason, 'unreachable');
+  assert.equal(wire.delivered.some(d => d.event === 'rom:offer'), false);
 });

--- a/core/test/sharing.test.ts
+++ b/core/test/sharing.test.ts
@@ -21,7 +21,7 @@ import { createSharing } from '../../frontend/src/lib/roms/sharing.js';
 
 const ROM = new Uint8Array([1, 2, 3]);
 const CRC = 'AAAA1111';
-const OFFER = { crc32: CRC, title: 'Umihara Kawase', from: 'friend-1' };
+const OFFER = { roomId: 'room-1', crc32: CRC, title: 'Umihara Kawase', from: 'friend-1' };
 
 function harness(over: Partial<Parameters<typeof createSharing>[0]> = {}) {
 	const emitted: Array<{ event: string; payload: unknown }> = [];
@@ -30,10 +30,13 @@ function harness(over: Partial<Parameters<typeof createSharing>[0]> = {}) {
 
 	const asked: string[] = [];
 	const deps = {
-		emit: (event: string, payload: unknown) => emitted.push({ event, payload }),
+		emit: (event: string, payload: unknown) => {
+			emitted.push({ event, payload });
+			return true;
+		},
 		resolve: async () => null,
-		receive: async (crc32: string) => {
-			asked.push(crc32);
+		receive: async (crc32: string, roomId: string) => {
+			asked.push(`${roomId}:${crc32}`);
 			return ROM;
 		},
 		keep: async (_bytes: Uint8Array, crc32: string, title: string) => {
@@ -61,17 +64,6 @@ test('une offre recue nomme le jeu et l ami', async () => {
 	assert.deepEqual(get(sharing.offered), OFFER);
 });
 
-test('une offre pour un jeu deja sur cet appareil n est pas posee', async () => {
-	const { sharing, emitted } = harness({ resolve: async () => ROM });
-
-	await sharing.offerReceived(OFFER);
-
-	// Celui qui offre ne sait pas ce que l autre possede. Poser la question
-	// pour un jeu deja la ferait repondre « oui » puis ne rien changer.
-	assert.equal(get(sharing.offered), null);
-	assert.deepEqual(emitted, []);
-});
-
 test('accepter demande le dump nomme, puis le garde et l inscrit', async () => {
 	const { sharing, kept, asked } = harness();
 	await sharing.offerReceived(OFFER);
@@ -82,7 +74,7 @@ test('accepter demande le dump nomme, puis le garde et l inscrit', async () => {
 	// consentement que le relais exige avant de laisser passer le moindre
 	// octet - voir `rom-relay.test.ts`. Ce qui compte ici est qu elle porte le
 	// dump offert, et pas celui que le salon porterait.
-	assert.deepEqual(asked, [CRC]);
+	assert.deepEqual(asked, [`room-1:${CRC}`]);
 	assert.deepEqual(kept, [{ crc32: CRC, title: 'Umihara Kawase' }]);
 	assert.equal(get(sharing.offered), null, 'la question se referme');
 });
@@ -93,7 +85,9 @@ test('refuser previent celui qui a offert, et ne garde rien', async () => {
 
 	sharing.decline();
 
-	assert.deepEqual(emitted, [{ event: 'rom:offer-declined', payload: { to: 'friend-1' } }]);
+	assert.deepEqual(emitted, [
+		{ event: 'rom:offer-declined', payload: { roomId: 'room-1', to: 'friend-1' } }
+	]);
 	assert.deepEqual(kept, []);
 	assert.equal(get(sharing.offered), null);
 });
@@ -156,4 +150,56 @@ test('une demande pour un dump que cet appareil n a pas recoit une reponse, pas 
 	assert.deepEqual(emitted, [
 		{ event: 'rom:unavailable', payload: { to: 'friend-1', reason: 'no-copy' } }
 	]);
+});
+
+test('une offre repond sur le salon qu elle nomme, pas sur celui que le client croit', async () => {
+	const { sharing, emitted } = harness();
+	await sharing.offerReceived({ ...OFFER, roomId: 'room-9' });
+
+	sharing.decline();
+
+	/*
+	 * Le serveur vient de valider l appartenance au salon avant de relayer
+	 * l offre. Repondre sur ce que le store local croit etre « mon salon »
+	 * ajoute une facon de perdre le message et rien d autre : ce store ignore
+	 * deliberement `room:updated`, et il peut donc etre en retard.
+	 */
+	assert.deepEqual(emitted, [
+		{ event: 'rom:offer-declined', payload: { roomId: 'room-9', to: 'friend-1' } }
+	]);
+});
+
+test('un jeu deja sur l appareil est refuse, pas ignore', async () => {
+	const { sharing, emitted } = harness({ resolve: async () => ROM });
+
+	await sharing.offerReceived(OFFER);
+
+	// Se taire laissait l offrant sur « En attente de… » pour toujours, sans
+	// que personne puisse savoir pourquoi.
+	assert.equal(get(sharing.offered), null, 'la question ne se pose pas');
+	assert.deepEqual(emitted, [
+		{
+			event: 'rom:offer-declined',
+			payload: { roomId: 'room-1', to: 'friend-1', reason: 'already-here' }
+		}
+	]);
+});
+
+test('offrir n attend rien si l emission n est pas partie', () => {
+	const { sharing } = harness({ emit: () => false });
+
+	sharing.offer(CRC, 'Umihara Kawase');
+
+	// Hors groupe ou sans socket, l emission est un non-evenement : afficher
+	// « En attente de… » serait annoncer une question que personne n a recue.
+	assert.equal(get(sharing.waiting), null);
+});
+
+test('un refus pour cause d injoignable arrete l attente', () => {
+	const { sharing } = harness();
+	sharing.offer(CRC, 'Umihara Kawase');
+
+	sharing.declined();
+
+	assert.equal(get(sharing.waiting), null);
 });

--- a/frontend/src/lib/roms/sharing.ts
+++ b/frontend/src/lib/roms/sharing.ts
@@ -24,6 +24,16 @@
 import { writable, type Readable } from 'svelte/store';
 
 export interface RomOffer {
+	/**
+	 * Le salon sur lequel l'offre est arrivée, et sur lequel on répond.
+	 *
+	 * Porté par l'offre plutôt que relu dans le store local, et c'est le
+	 * correctif du 2026-09-10 : le serveur vient de valider l'appartenance
+	 * avant de relayer, donc recouper avec ce que le client croit être « mon
+	 * salon » n'ajoute qu'une façon de perdre le message - `my-room.ts`
+	 * ignore délibérément `room:updated` et peut être en retard.
+	 */
+	roomId: string;
 	crc32: string;
 	title: string;
 	/** L'ami qui propose, tel que le relais le nomme. */
@@ -31,11 +41,18 @@ export interface RomOffer {
 }
 
 export interface SharingDeps {
-	emit(event: string, payload: unknown): void;
+	/** Rend `false` quand rien n'est parti - pas de salon, pas de socket. */
+	emit(event: string, payload: unknown): boolean;
 	/** Les octets, si cet appareil les a déjà. */
 	resolve(crc32: string): Promise<Uint8Array | null>;
-	/** Attend le transfert, une fois la demande partie. */
-	receive(crc32: string): Promise<Uint8Array>;
+	/**
+	 * Attend le transfert, une fois la demande partie.
+	 *
+	 * Le salon vient de l'offre, comme la réponse : la demande d'acceptation
+	 * est elle aussi portée par le relais, et l'envoyer sur le mauvais salon
+	 * la ferait jeter.
+	 */
+	receive(crc32: string, roomId: string): Promise<Uint8Array>;
 	/** Accepter, c'est avoir le jeu : garder les octets ET inscrire la fiche. */
 	keep(bytes: Uint8Array, crc32: string, title: string): Promise<void>;
 	send(to: string, bytes: Uint8Array): Promise<void>;
@@ -68,8 +85,10 @@ export function createSharing(deps: SharingDeps): Sharing {
 		waiting: { subscribe: waiting.subscribe },
 
 		offer(crc32, title) {
-			waiting.set(crc32);
-			deps.emit('rom:offer', { crc32, title });
+			// L'attente seulement si la question est partie : hors groupe ou
+			// sans socket, afficher « En attente de… » annonce une question
+			// que personne n'a reçue.
+			if (deps.emit('rom:offer', { crc32, title })) waiting.set(crc32);
 		},
 
 		declined() {
@@ -93,8 +112,17 @@ export function createSharing(deps: SharingDeps): Sharing {
 
 		async offerReceived(offer) {
 			// Celui qui offre ne sait pas ce que l'autre possède déjà. Poser la
-			// question pour un jeu qui est là ferait répondre oui pour rien.
-			if (await deps.resolve(offer.crc32)) return;
+			// question pour un jeu qui est là ferait répondre oui pour rien -
+			// mais se taire laissait l'offrant sur « En attente de… » pour
+			// toujours, sans que personne puisse savoir pourquoi.
+			if (await deps.resolve(offer.crc32)) {
+				deps.emit('rom:offer-declined', {
+					roomId: offer.roomId,
+					to: offer.from,
+					reason: 'already-here'
+				});
+				return;
+			}
 			pending = offer;
 			offered.set(offer);
 		},
@@ -109,7 +137,7 @@ export function createSharing(deps: SharingDeps): Sharing {
 			offered.set(null);
 
 			try {
-				const bytes = await deps.receive(offer.crc32);
+				const bytes = await deps.receive(offer.crc32, offer.roomId);
 				await deps.keep(bytes, offer.crc32, offer.title);
 			} catch {
 				// Rien n'est gardé à moitié, et l'ami peut reproposer. Le module
@@ -123,7 +151,7 @@ export function createSharing(deps: SharingDeps): Sharing {
 			if (!offer) return;
 			pending = null;
 			offered.set(null);
-			deps.emit('rom:offer-declined', { to: offer.from });
+			deps.emit('rom:offer-declined', { roomId: offer.roomId, to: offer.from });
 		}
 	};
 }

--- a/frontend/src/lib/stores/sharing.ts
+++ b/frontend/src/lib/stores/sharing.ts
@@ -37,20 +37,32 @@ export function sharing(): Sharing {
 
   instance = createSharing({
     emit(event, payload) {
-      const id = roomId();
-      // Hors groupe il n'y a personne à qui parler, et le relais refuserait
-      // de toute façon : tout passe par l'appartenance au salon.
-      if (!id) return;
-      get(socket)?.emit(event, { roomId: id, ...(payload as object) });
+      /*
+       * Le salon que la charge utile porte l'emporte sur celui du store.
+       *
+       * Une réponse à une offre répond sur le salon de l'offre - le serveur
+       * vient de valider l'appartenance avant de la relayer. Ne consulter
+       * `myRoom` que pour ce qui part d'ici, c'est-à-dire l'offre elle-même.
+       */
+      const carried = (payload as { roomId?: string }).roomId;
+      const id = carried ?? roomId();
+      const sock = get(socket);
+      // Rendre `false` plutôt que se taire : l'appelant décide si une
+      // question qui n'est pas partie doit quand même afficher une attente.
+      if (!id || !sock) {
+        logger.warn('nothing sent: no room or no socket', { event, room: id ?? null });
+        return false;
+      }
+      sock.emit(event, { roomId: id, ...(payload as object) });
+      return true;
     },
 
     resolve: (crc32) => resolveQuietly(crc32, { requestPermission: false }),
 
-    receive(crc32) {
-      const id = roomId();
+    receive(crc32, roomId) {
       const sock = get(socket);
-      if (!id || !sock) return Promise.reject(new Error('no room to receive in'));
-      return receiveRom({ socket: sock as never, roomId: id, expectedCrc32: crc32 });
+      if (!sock) return Promise.reject(new Error('no socket to receive on'));
+      return receiveRom({ socket: sock as never, roomId, expectedCrc32: crc32 });
     },
 
     async keep(bytes, crc32, title) {
@@ -68,7 +80,10 @@ export function sharing(): Sharing {
     async send(to, bytes) {
       const id = roomId();
       const sock = get(socket);
-      if (!id || !sock) return;
+      if (!id || !sock) {
+        logger.warn('asked to send a ROM with no room or no socket');
+        return;
+      }
       await sendRom({
         socket: sock as never,
         roomId: id,

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -80,21 +80,37 @@
   const share = sharing();
 
   function onShareOffered(offer: { roomId: string; crc32: string; title: string; from: string }) {
-    if (!offer || offer.roomId !== get(myRoom)?.id) return;
-    void share.offerReceived({ crc32: offer.crc32, title: offer.title, from: offer.from });
+    if (!offer?.roomId || !offer.crc32) return;
+    /*
+     * Plus de recoupement avec `myRoom`.
+     *
+     * Il y en avait un, et c'était une façon de perdre le message sans rien
+     * gagner : le serveur valide l'appartenance au salon avant de relayer
+     * l'offre, et `my-room.ts` ignore délibérément `room:updated`, donc le
+     * store local peut être en retard sur ce que le serveur sait déjà. Le
+     * 2026-09-10, « l'ami ne voit jamais de message » a été indécidable
+     * précisément parce que ce rejet ne disait rien.
+     *
+     * Journalisé à l'arrivée : les journaux du client remontent au backend,
+     * donc la prochaine offre dira elle-même si elle est arrivée jusqu'ici.
+     */
+    logger.info('a friend offered a game', { crc32: offer.crc32, room: offer.roomId });
+    void share.offerReceived(offer);
   }
 
   function onShareRequested(data: { roomId: string; from: string; crc32?: string }) {
     // Sans `crc32` c'est une demande de partie, et une salle s'en occupe déjà.
-    if (!data?.crc32 || data.roomId !== get(myRoom)?.id) return;
+    if (!data?.crc32) return;
     // Et seulement hors salon : dans une partie, `LockstepRoom` répond, avec
     // ses octets déjà chargés et son garde contre les doubles envois.
     if (get(inGame)) return;
     void share.requested(data.from, data.crc32);
   }
 
-  function onShareDeclined(data: { roomId: string }) {
-    if (data?.roomId !== get(myRoom)?.id) return;
+  function onShareDeclined(data: { roomId: string; reason?: string }) {
+    // Le relais ne l'envoie qu'à un membre du salon concerné ; le recouper
+    // ici ne pourrait que le perdre.
+    logger.info('the offer came back', { reason: data?.reason ?? 'declined' });
     share.declined();
   }
 


### PR DESCRIPTION
> *"J'ai bien le bouton pour envoyer le jeu mais l'ami ne voit jamais de message pour accepter"* — twice, the second time **after both players hard refreshed**, so it is not a stale bundle.

## What the telemetry proves, and what it doesn't

```
12:56:16  Invitation sent      → delivered:true
12:56:22  Invitation accepted  → the friend is seated
12:56:29  A player offered a game   crc32 C11899BF
13:02:19  A player offered a game   crc32 C11899BF   (after both refreshed)
```

The friend was a seated member with a live socket seven seconds before the offer, and a disconnect leaves membership alone (*"away, not gone"*). The DB says they do not own that dump. So the relay forwarded it and **the receiving client showed nothing.**

Which of the ways it can show nothing actually fired is still unknown — and *that* is the real defect. There were four, and every one of them was silent.

## The four silences

| | Now |
|---|---|
| `rom:offer` logged *"A player offered a game"* **before** knowing whether anyone was reachable, and told the offerer nothing when nobody was | counts the recipients, logs the count, and answers `rom:offer-declined { reason: 'unreachable' }` when the room holds nobody else reachable |
| the layout dropped any offer whose `roomId` did not match the local `myRoom` | **gone** — the server validates membership before relaying, and `my-room.ts` deliberately ignores `room:updated`, so the local store can be behind what the server already knows. Re-checking could only lose the message |
| suppressing the card because the game is already on this device told nobody, leaving the offerer on *"En attente de…"* for good | declines with `reason: 'already-here'` |
| `offer()` set the waiting state even when the emit was a no-op | `emit` returns whether anything went out |

**One more of the same kind, and the best guess at the cause:** accepting went through `myRoom` too. The offer now carries its own `roomId`, and both the answer and the transfer request reply on *that* room rather than on whatever the store believes.

An arriving offer is now logged on the client, and client logs ship to the backend — so the next attempt will say for itself whether it reached the friend. *Build the instrument first:* the loud version of this bug would have been diagnosed in one round trip.

## Testing

- 5 new tests written failing first: the unreachable offer answers; a reply goes to the room the offer names and not the one the client believes; an already-present game is refused rather than ignored; no emit means no waiting state.
- `bun run test:all` — 130 + 20 + 951 + 383. Full e2e on a fresh database: **52/52**.
- Two real browsers: the card appears, and a refusal brings the sender's button back from *"En attente de…"* to *"Envoyer à DevTwo"* instead of leaving it stuck.

**This is not proof the reported bug is fixed** — only that every way it could hide is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
