### PR TITLE
Make the ROM folder say why it did not take the file

### DIFF
--- a/core/test/rom-provider.test.ts
+++ b/core/test/rom-provider.test.ts
@@ -445,3 +445,42 @@ test('un dossier qui refuse n empeche pas de garder', async () => {
 	assert.deepEqual(await kept.checksums(), [checksum]);
 	useKeptFiles(null);
 });
+
+test('garder dit pourquoi le dossier n a pas recu le fichier', async () => {
+	const { keepReceived, useKeptFiles } = await provider();
+	const { memoryKeptFiles } = await import('../../frontend/src/lib/roms/kept-files.js');
+	useKeptFiles(memoryKeptFiles());
+
+	const seen: string[] = [];
+	await keepReceived(rom(35), {
+		title: 'Refuse',
+		writeToFolder: async () => 'no-permission',
+		onFolder: (outcome: string) => seen.push(outcome)
+	});
+
+	/*
+	 * « Le fichier n est pas dans mon dossier de roms » n etait pas
+	 * diagnosticable : `writeRomToFolder` rendait un booleen et renoncait sans
+	 * un mot, alors qu il y a quatre raisons distinctes de renoncer - et une
+	 * seule, `no-permission`, a un remede que le joueur peut appliquer
+	 * lui-meme sur sa page de profil. Signale le 2026-09-10.
+	 */
+	assert.deepEqual(seen, ['no-permission']);
+	useKeptFiles(null);
+});
+
+test('un dossier qui a recu le fichier le dit aussi', async () => {
+	const { keepReceived, useKeptFiles } = await provider();
+	const { memoryKeptFiles } = await import('../../frontend/src/lib/roms/kept-files.js');
+	useKeptFiles(memoryKeptFiles());
+
+	const seen: string[] = [];
+	await keepReceived(rom(36), {
+		title: 'Written',
+		writeToFolder: async () => 'written',
+		onFolder: (outcome: string) => seen.push(outcome)
+	});
+
+	assert.deepEqual(seen, ['written']);
+	useKeptFiles(null);
+});

--- a/frontend/src/lib/components/VrShell.svelte
+++ b/frontend/src/lib/components/VrShell.svelte
@@ -2067,7 +2067,10 @@
    */
   async function keepAndRegister(bytes: Uint8Array, crc32: string): Promise<void> {
     const title = $myRoom?.gameTitle ?? '';
-    await keepReceived(bytes, { title });
+    await keepReceived(bytes, {
+      title,
+      onFolder: (outcome) => logger.info('the ROM folder', { outcome })
+    });
     try {
       await registerGame(crc32, romFileName(title, crc32));
     } catch (err) {

--- a/frontend/src/lib/roms/keep-offer.ts
+++ b/frontend/src/lib/roms/keep-offer.ts
@@ -69,7 +69,11 @@ export interface KeepOffer {
 export function createKeepOffer(deps: KeepOfferDeps = {}): KeepOffer {
 	const keep =
 		deps.keep ??
-		((bytes: Uint8Array, title?: string) => keepReceived(bytes, { title }));
+		((bytes: Uint8Array, title?: string) =>
+			keepReceived(bytes, {
+				title,
+				onFolder: (outcome) => logger.info('the ROM folder', { outcome })
+			}));
 	const available = deps.available ?? keptFilesAvailable;
 	/*
 	 * `registerGame` veut un nom de fichier, et un jeu reçu n'en a pas : les

--- a/frontend/src/lib/roms/local-library.ts
+++ b/frontend/src/lib/roms/local-library.ts
@@ -180,18 +180,42 @@ export async function ensureWriteAccess(handle: FileSystemDirectoryHandle): Prom
 }
 
 /**
+ * Why the player's folder did not receive the file - or that it did.
+ *
+ * A boolean was not enough, and that cost a round trip on 2026-09-10: "le
+ * fichier n'est pas dans mon dossier de roms" had four possible causes and
+ * only one of them, `no-permission`, has a remedy the player can apply
+ * themselves. On the same model as `MissReason` in `provider.ts`.
+ */
+export type FolderWrite =
+	/** The file is in the folder. */
+	| 'written'
+	/** No directory picker in this browser; the device store is all there is. */
+	| 'no-picker'
+	/** No folder has ever been chosen on this device. */
+	| 'no-folder'
+	/** A folder is stored, but writing to it was never granted - profile page. */
+	| 'no-permission'
+	/** The write itself failed: a folder that moved, a full disk, a refused name. */
+	| 'failed';
+
+/**
  * Writes a ROM into the player's folder, if that is possible without asking.
  *
- * Best effort by design, and it says so by returning a boolean rather than
- * throwing: this runs while a game is on screen, the answer changes nothing
+ * Best effort by design, and it says so by returning an outcome rather than
+ * throwing: this can run while a game is on screen, the answer changes nothing
  * the player asked for - the bytes are kept in the device store either way -
  * and the one thing it must not do is interrupt.
  */
-export async function writeRomToFolder(name: string, bytes: Uint8Array): Promise<boolean> {
+export async function writeRomToFolder(name: string, bytes: Uint8Array): Promise<FolderWrite> {
 	try {
-		if (!supportsDirectoryPicker()) return false;
+		if (!supportsDirectoryPicker()) return 'no-picker';
 		const handle = await storedDirectory();
-		if (!handle || !(await hasWriteAccess(handle))) return false;
+		if (!handle) return 'no-folder';
+		// La permission d'écriture est distincte de celle de lecture, et aucun
+		// dossier choisi avant le 2026-09-10 ne l'a accordée : le sélecteur
+		// demandait `mode: 'read'`. Le geste vit sur le panneau ROMs du profil.
+		if (!(await hasWriteAccess(handle))) return 'no-permission';
 
 		const file = await handle.getFileHandle(name, { create: true });
 		const writable = await (
@@ -199,12 +223,13 @@ export async function writeRomToFolder(name: string, bytes: Uint8Array): Promise
 		).createWritable();
 		await writable.write(bytes);
 		await writable.close();
-		return true;
+		return 'written';
 	} catch {
 		// A folder that moved, a disk that is full, a name the filesystem
-		// refuses. None of it is worth a word on screen: the game is running
-		// and the bytes are safe in the device store.
-		return false;
+		// refuses. None of it is worth a word on screen - the bytes are safe
+		// in the device store - but the caller logs it, so it is no longer
+		// invisible.
+		return 'failed';
 	}
 }
 

--- a/frontend/src/lib/roms/provider.ts
+++ b/frontend/src/lib/roms/provider.ts
@@ -27,7 +27,8 @@ import {
 	romBytes,
 	storedDirectory,
 	supportsDirectoryPicker,
-	writeRomToFolder
+	writeRomToFolder,
+	type FolderWrite
 } from './local-library.js';
 import { romFileName } from './rom-file.js';
 import {
@@ -114,7 +115,16 @@ export interface KeepReceivedOptions {
 	 */
 	title?: string;
 	/** Un seam, pour la raison que `useKeptFiles` donne : ceci veut le disque. */
-	writeToFolder?: (name: string, bytes: Uint8Array) => Promise<boolean>;
+	writeToFolder?: (name: string, bytes: Uint8Array) => Promise<FolderWrite>;
+	/**
+	 * Ce que le dossier a fait du fichier.
+	 *
+	 * Rapporté plutôt que tu : « le fichier n'est pas dans mon dossier de
+	 * roms » avait quatre causes possibles et renonçait sans un mot. Ce module
+	 * n'a pas le contexte qui rendrait une ligne de log lisible, l'appelant si
+	 * - la même division que `onMiss`.
+	 */
+	onFolder?: (outcome: FolderWrite) => void;
 }
 
 export async function keepReceived(
@@ -139,7 +149,13 @@ export async function keepReceived(
 	 * sur le panneau ROMs du profil.
 	 */
 	const write = options.writeToFolder ?? writeRomToFolder;
-	await write(romFileName(options.title ?? '', checksum), bytes);
+	// L'écriture d'abord, le rapport ensuite. `options.onFolder?.(await …)`
+	// n'évalue PAS son argument quand le rappel est absent - l'appel optionnel
+	// court-circuite tout - donc cette forme-là cessait d'écrire dans le
+	// dossier pour chaque appelant qui ne passe pas de rappel. Attrapé par un
+	// test qui existait déjà.
+	const outcome = await write(romFileName(options.title ?? '', checksum), bytes);
+	options.onFolder?.(outcome);
 
 	return checksum;
 }

--- a/frontend/src/lib/stores/sharing.ts
+++ b/frontend/src/lib/stores/sharing.ts
@@ -78,7 +78,14 @@ export function sharing(): Sharing {
       // Accepter, c'est avoir le jeu : les octets ET la fiche. Garder sans
       // inscrire laissait le joueur sans carte à cliquer, ce que le
       // 2026-09-10 a déjà appris une fois.
-      await keepReceived(bytes, { title });
+      await keepReceived(bytes, {
+        title,
+        // Le dossier renonçait sans un mot, et « le fichier n'est pas dans
+        // mon dossier de roms » avait quatre causes possibles. `no-permission`
+        // est la seule qui ait un remède que le joueur applique lui-même,
+        // sur le panneau ROMs de son profil.
+        onFolder: (outcome) => logger.info('the ROM folder', { outcome })
+      });
       try {
         await registerGame(crc32, romFileName(title, crc32));
         /*


### PR DESCRIPTION
> *"Le fichier n'est pas dans mon dossier de roms, il n'y a pas eu de téléchargement."*

Most likely the folder is **read-only**: the picker asked for `mode: 'read'` until this morning, so no folder chosen before then has ever granted writing, and the remedy is one button on the profile page — *Autoriser l'écriture*.

But *"most likely"* is exactly what this session has been paying for all afternoon.

## Changes

`writeRomToFolder` returned a boolean and gave up without a word, and there are **four distinct ways to give up** — `no-picker`, `no-folder`, `no-permission`, `failed` — of which only `no-permission` has a remedy the player can apply themselves. It returns a `FolderWrite` outcome now, on the same model as `MissReason` next door, and every keep path logs it (`the ROM folder { outcome }`). Client logs reach the backend, so the next attempt says which one it was instead of leaving us to guess.

## One defect introduced and caught in the same minute

By a test that already existed:

```js
options.onFolder?.(await write(…))   // ← never calls write when onFolder is absent
```

An optional call **short-circuits the whole expression**, arguments included, so that form silently stopped writing to the folder for every caller that passes no callback. The write happens first now, and the report second.

## Testing

- 2 new tests on the reported outcome, written failing first; the pre-existing folder-write test is what caught the short-circuit.
- `bun run test:all` — 130 + 20 + 958 + 385, all green. `svelte-check` 0 errors, frontend build clean.

Still not covered by any test, and said again because it has not changed: the native directory picker and the write permission cannot be driven in Playwright, so `writeRomToFolder` itself has never run in a test. What is tested is the decision and the reporting around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
