### PR TITLE
Ask for the ROM folder when accepting a game, not on a profile page

### DIFF
--- a/core/test/sharing.test.ts
+++ b/core/test/sharing.test.ts
@@ -29,14 +29,22 @@ function harness(over: Partial<Parameters<typeof createSharing>[0]> = {}) {
 	const sent: Array<{ to: string; bytes: Uint8Array }> = [];
 
 	const asked: string[] = [];
+	const order: string[] = [];
 	const deps = {
 		inLibrary: async () => false,
+		grantFolderWrite: async () => {
+			order.push('grant');
+		},
 		emit: (event: string, payload: unknown) => {
 			emitted.push({ event, payload });
 			return true;
 		},
-		resolve: async () => null,
+		resolve: async () => {
+			order.push('resolve');
+			return null;
+		},
 		receive: async (crc32: string, roomId: string) => {
+			order.push('receive');
 			asked.push(`${roomId}:${crc32}`);
 			return ROM;
 		},
@@ -49,7 +57,7 @@ function harness(over: Partial<Parameters<typeof createSharing>[0]> = {}) {
 		...over
 	};
 
-	return { sharing: createSharing(deps), emitted, kept, sent, asked };
+	return { sharing: createSharing(deps), emitted, kept, sent, asked, order };
 }
 
 test('rien n est propose tant qu aucune offre n arrive', () => {
@@ -269,4 +277,31 @@ test('offrir a nouveau efface la reponse precedente', () => {
 
 	// Sinon « il a deja ce jeu » resterait affiche sous un bouton qui attend.
 	assert.equal(get(sharing.answer), null);
+});
+
+test('accepter demande l acces en ecriture avant tout le reste', async () => {
+	const { sharing, order } = harness();
+	await sharing.offerReceived(OFFER);
+	order.length = 0;
+
+	await sharing.accept();
+
+	/*
+	 * `requestPermission` exige une activation transitoire, et chaque `await`
+	 * la consomme : demandee apres le transfert - plusieurs secondes - elle
+	 * serait rejetee. Le clic sur « Le recevoir » est le seul moment ou elle
+	 * peut aboutir, et c est aussi le bon moment humainement : personne ne
+	 * joue, contrairement a la question posee a cote d une partie.
+	 */
+	assert.equal(order[0], 'grant', `ordre obtenu : ${order.join(' -> ')}`);
+});
+
+test('un refus n a rien a demander au dossier', async () => {
+	const { sharing, order } = harness();
+	await sharing.offerReceived(OFFER);
+	order.length = 0;
+
+	sharing.decline();
+
+	assert.deepEqual(order, []);
 });

--- a/frontend/src/lib/roms/sharing.ts
+++ b/frontend/src/lib/roms/sharing.ts
@@ -62,6 +62,20 @@ export interface SharingDeps {
 	 */
 	inLibrary(crc32: string): Promise<boolean>;
 	/**
+	 * Demander au dossier du joueur le droit d'y écrire, si ce n'est pas déjà
+	 * accordé.
+	 *
+	 * Appelé en premier dans `accept`, et c'est une contrainte du navigateur
+	 * plutôt qu'un choix : `requestPermission` exige une activation
+	 * transitoire, et chaque `await` la consomme - demandée après le transfert
+	 * elle serait rejetée. C'est aussi le bon moment humainement, et c'est
+	 * tout l'intérêt d'avoir sorti le partage du lancement : personne ne joue,
+	 * donc une boîte de dialogue native ne fait caler personne. La question
+	 * posée à côté d'une partie, elle, n'en demande toujours pas - voir
+	 * `keep-offer.ts`.
+	 */
+	grantFolderWrite(): Promise<void>;
+	/**
 	 * Attend le transfert, une fois la demande partie.
 	 *
 	 * Le salon vient de l'offre, comme la réponse : la demande d'acceptation
@@ -170,6 +184,10 @@ export function createSharing(deps: SharingDeps): Sharing {
 			// prend le relais, et une carte qui reste pendant l'envoi invite à
 			// re-cliquer.
 			offered.set(null);
+
+			// Avant tout `await` qui compte : l'activation du clic est ce qui
+			// autorise l'invite, et elle ne survit pas au transfert.
+			await deps.grantFolderWrite();
 
 			try {
 				/*

--- a/frontend/src/lib/stores/sharing.ts
+++ b/frontend/src/lib/stores/sharing.ts
@@ -19,7 +19,12 @@ import { myRoom } from '$lib/rooms/my-room';
 import { games, loadGames } from '$lib/stores/games';
 import { createSharing, type Sharing } from '$lib/roms/sharing';
 import { resolveQuietly, keepReceived } from '$lib/roms/provider';
-import { registerGame } from '$lib/roms/local-library';
+import {
+  registerGame,
+  supportsDirectoryPicker,
+  storedDirectory,
+  ensureWriteAccess
+} from '$lib/roms/local-library';
 import { romFileName } from '$lib/roms/rom-file';
 import { receiveRom, sendRom } from '$lib/roms/transfer';
 import { createLogger } from '$lib/utils/logger';
@@ -67,6 +72,28 @@ export function sharing(): Sharing {
      * « ce jeu est-il à moi » se lit dedans sans requête.
      */
     inLibrary: async (crc32) => get(games).some((g) => g.crc32 === crc32),
+
+    /*
+     * Le clic sur « Le recevoir » est le seul moment où cette invite peut
+     * aboutir - `requestPermission` veut une activation transitoire - et le
+     * seul où elle ne dérange personne, puisque aucune partie ne tourne.
+     * Silencieuse si le dossier est déjà en écriture, et sans objet s'il n'y
+     * a pas de dossier : on n'ouvre pas de sélecteur ici, seulement la
+     * permission sur ce que le joueur a déjà confié.
+     */
+    async grantFolderWrite() {
+      try {
+        if (!supportsDirectoryPicker()) return;
+        const handle = await storedDirectory();
+        if (!handle) return;
+        const granted = await ensureWriteAccess(handle);
+        logger.info('write access to the ROM folder', { granted });
+      } catch (err) {
+        // Un refus n'empêche pas de recevoir le jeu : les octets vont dans le
+        // magasin du navigateur comme avant.
+        logger.warn('could not ask for write access to the ROM folder', err);
+      }
+    },
 
     receive(crc32, roomId) {
       const sock = get(socket);


### PR DESCRIPTION
> *"Ça marche après avoir accordé cette autorisation! donc idéalement, il faudrait que le bouton qui accepte le jeu autorise aussi l'accès en écriture."*

Consistent with this morning's ruling rather than against it. The call then was **"never a prompt during a match"**, and it was right: a native dialog takes the keyboard, and a lockstep player who sends no inputs stalls the other. Accepting a shared game from the library is the opposite situation — nobody is playing, which is the whole reason sharing was taken out of the launch — so the prompt disturbs no one there.

## The constraint that shapes it

It goes **first** in `accept`, before any `await` that matters, and that is a browser constraint rather than a preference: `requestPermission` needs **transient activation** and every await spends it, so asked after the transfer — seconds later — it would simply be refused.

A test pins the ordering (`order[0] === 'grant'`), because moving it one line down would break this silently and nothing else would notice.

## Three ways it stays out of the way

- **Silent when writing is already granted** — `ensureWriteAccess` returns without prompting, so it is not an extra dialog on every accept.
- **Moot when there is no folder** — this asks for permission on what the player has already entrusted; it does not open a picker.
- **A refusal costs nothing** — the bytes go to the device store exactly as before.

The profile button stays, for whoever wants to grant it without waiting for a friend to send them something.

## Testing

- 2 new tests written failing first: accepting asks the folder before anything else; declining asks it nothing.
- `bun run test:all` — 130 + 20 + 960 + 385, all green. Full e2e on a fresh database: **52/52**. `svelte-check` 0 errors, frontend build clean.

The permission prompt itself still cannot be driven in Playwright — what is tested is that the request is made, and when.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
