### PR TITLE
Paint three buttons, and remove one

### DIFF
--- a/frontend/src/lib/components/GameDetailsModal.svelte
+++ b/frontend/src/lib/components/GameDetailsModal.svelte
@@ -243,9 +243,29 @@
     cursor: default;
   }
 
+  /* Peint comme ses voisins de la même colonne. Il ne portait que sa marge
+     et sa largeur, donc le bouton brut du navigateur juste sous deux boutons
+     habillés - la même omission que `.share` plus tôt dans la journée. */
   .export-saves {
     margin-top: 0.5rem;
     width: 100%;
+    background: transparent;
+    border: 1px solid #3d3d52;
+    color: #b7b7cc;
+    border-radius: 6px;
+    padding: 0.45rem 1rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+
+  .export-saves:hover:not(:disabled) {
+    border-color: #667eea;
+    color: #fff;
+  }
+
+  .export-saves:disabled {
+    opacity: 0.6;
+    cursor: default;
   }
 
   .export-error {

--- a/frontend/src/lib/components/SavesPortabilityPanel.svelte
+++ b/frontend/src/lib/components/SavesPortabilityPanel.svelte
@@ -143,6 +143,25 @@
 </section>
 
 <style>
+  /* Le bouton de `RomSourcePanel`, à l'identique : ces deux panneaux sont
+     côte à côte sur la page de profil, et il n'y avait ici aucune règle du
+     tout - donc le bouton brut du navigateur, blanc et carré, à côté de son
+     voisin habillé. Signalé le 2026-09-10 : « ya plein de boutons sans style
+     comme Télécharger mes sauvegardes ». */
+  button {
+    background: #333;
+    border: 2px solid transparent;
+    color: #fff;
+    padding: 0.4rem 0.75rem;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
   h3 {
     margin: 0 0 0.25rem;
     font-size: 0.95rem;

--- a/frontend/src/lib/i18n/translations.ts
+++ b/frontend/src/lib/i18n/translations.ts
@@ -123,6 +123,7 @@ export const translations = {
     scanningFolder: 'Reading the folder…',
     romsNoneAdded: 'None of the games could be added.',
     noRomsFound: 'No SNES ROM in that folder.',
+    metadataFilled: '{count} entries filled in',
     gamesAdded: 'games added',
     gamesRemoved: 'games no longer in the folder',
     refreshLibrary: 'Rescan the folder',
@@ -169,12 +170,8 @@ export const translations = {
     noneOnThisDevice: 'None of your {count} games are on this device',
     noneOnThisDeviceHint:
       'Your account still holds them. Point this device at your ROM folder, or add a file, and they come back.',
-    updateMetadata: 'Update Metadata',
-    updating: 'Updating...',
-    metadataUpdated: 'Metadata updated! {updated} game(s) matched, {skipped} skipped.',
     failedToRefreshMetadata: 'Failed to refresh metadata',
     errorRefreshingMetadata: 'Error refreshing metadata',
-    metadataUpdateFailed: 'Could not update the metadata.',
 
     // Delete game
     deleteGame: 'Delete Game?',
@@ -696,6 +693,7 @@ export const translations = {
     scanningFolder: 'Lecture du dossier…',
     romsNoneAdded: 'Aucun jeu n\'a pu être ajouté.',
     noRomsFound: 'Aucune ROM SNES dans ce dossier.',
+    metadataFilled: '{count} fiches complétées',
     gamesAdded: 'jeux ajoutés',
     gamesRemoved: 'jeux plus présents dans le dossier',
     refreshLibrary: 'Rescanner le dossier',
@@ -742,12 +740,8 @@ export const translations = {
     noneOnThisDevice: 'Aucun de vos {count} jeux n\'est sur cet appareil',
     noneOnThisDeviceHint:
       'Votre compte les garde. Désignez le dossier de vos ROMs, ou ajoutez un fichier, et ils réapparaissent.',
-    updateMetadata: 'Mettre à jour les métadonnées',
-    updating: 'Mise à jour...',
-    metadataUpdated: 'Métadonnées mises à jour ! {updated} jeu(x) trouvé(s), {skipped} ignoré(s).',
     failedToRefreshMetadata: 'Échec de la mise à jour des métadonnées',
     errorRefreshingMetadata: 'Erreur lors de la mise à jour des métadonnées',
-    metadataUpdateFailed: 'Impossible de mettre à jour les métadonnées.',
 
     // Delete game
     deleteGame: 'Supprimer le jeu ?',

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -107,6 +107,33 @@
     folderKnown = !!(await storedDirectory().catch(() => undefined));
   });
 
+  /**
+   * Complète les fiches des jeux du compte depuis le catalogue.
+   *
+   * Repliée dans le rescan plutôt que sur son propre bouton du profil, à la
+   * demande du propriétaire : « rescanner le dossier » veut dire « remets ma
+   * bibliothèque d'aplomb », et une fiche manquante en fait partie autant
+   * qu'un fichier ajouté. Deux gestes pour une intention, dont un caché sur
+   * une autre page, c'était un de trop.
+   *
+   * Avalée en cas d'échec : ce n'est pas la raison du clic, et le rescan a
+   * déjà fait le travail qui l'était.
+   */
+  async function fillInMetadata(): Promise<number> {
+    try {
+      const res = await fetch('/api/games/refresh-metadata', {
+        method: 'POST',
+        credentials: 'include'
+      });
+      if (!res.ok) return 0;
+      const result = await res.json();
+      return typeof result?.updated === 'number' ? result.updated : 0;
+    } catch (err) {
+      logger.warn('could not fill in the metadata during a rescan', err);
+      return 0;
+    }
+  }
+
   async function rescanFolder(): Promise<void> {
     syncing = true;
     syncNote = '';
@@ -142,6 +169,10 @@
         return;
       }
 
+      // Après l'inscription, pour que les jeux tout juste ajoutés en
+      // profitent aussi.
+      const filled = await fillInMetadata();
+
       // Les deux listes que la grille croise : ce que le compte possède, et ce
       // que cet appareil sait résoudre. Rafraîchir l'une sans l'autre laisse un
       // jeu ajouté invisible, ou un jeu retiré encore affiché.
@@ -149,6 +180,7 @@
       await refreshResolvable();
 
       const parts: string[] = [];
+      if (filled > 0) parts.push(t($language, 'metadataFilled', { count: filled }));
       if (result.added > 0) parts.push(`${result.added} ${t($language, 'gamesAdded')}`);
       if (result.removed > 0) parts.push(`${result.removed} ${t($language, 'gamesRemoved')}`);
       if (parts.length > 0) {

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -51,8 +51,6 @@
   let controlsConfig: ControlsConfig | null = null;
   let controlsError = '';
   let shader = '';
-  let refreshing = false;
-  let refreshMessage = '';
   let configBusy = false;
   let configMessage = '';
   let configError = '';
@@ -346,30 +344,6 @@
     }
   }
 
-  async function refreshMetadata(): Promise<void> {
-    refreshing = true;
-    refreshMessage = '';
-    try {
-      const res = await fetch('/api/games/refresh-metadata', {
-        method: 'POST',
-        credentials: 'include'
-      });
-      if (res.ok) {
-        const result = await res.json();
-        refreshMessage = t($language, 'metadataUpdated', {
-          updated: result.updated,
-          skipped: result.skipped
-        });
-      } else {
-        refreshMessage = t($language, 'metadataUpdateFailed');
-      }
-    } catch {
-      refreshMessage = t($language, 'metadataUpdateFailed');
-    } finally {
-      refreshing = false;
-    }
-  }
-
   async function logout(): Promise<void> {
     loggingOut = true;
     logoutMessage = '';
@@ -536,14 +510,6 @@
         {#each configNotices as notice}
           <p class="note">{t($language, NOTICES[notice])}</p>
         {/each}
-      </section>
-
-      <section class="card">
-        <h2>{t($language, 'library')}</h2>
-        <button on:click={refreshMetadata} disabled={refreshing}>
-          {refreshing ? t($language, 'updating') : t($language, 'updateMetadata')}
-        </button>
-        {#if refreshMessage}<p class="note">{refreshMessage}</p>{/if}
       </section>
 
       <!-- Next to the ROM folder panel on purpose: both answer "what of mine


### PR DESCRIPTION
Two reports, two commits.

## "Ya plein de boutons sans style comme Télécharger mes sauvegardes"

**Three, in the end** — but two of them sit side by side on the profile page, which is what makes it look like more.

- **`SavesPortabilityPanel` had no button rule at all**, so both of its buttons drew the browser's raw one — white and square — beside `RomSourcePanel`'s dressed ones on the same page. It takes that panel's button now, character for character: two panels of one screen, and two styles there would read as two places.
- **`.export-saves`** in the details modal carried only its margin and its width, sitting under two painted buttons. The same omission as `.share` this morning, and the same fix, borrowed from `.identify` beside it.

Found by sweeping all 35 components for buttons that set neither background nor border. Worth recording that **the sweep lied twice before it was right**: CSS comments contain `:` and `;` and broke the declaration split, then nested `@media` blocks broke the rule split. Fifteen candidates became three once each was checked by hand, and the render settled it.

*Not shown in a capture:* `.export-saves` only appears with a real save, and a save is only ever written over the socket during a game. Its rule is copied from `.identify`, which I have watched render in that same modal.

## "Virer le bouton Mettre à jour les métadonnées, et faire cette mise à jour au Rescanner le dossier"

Two gestures for one intention, and one of them hidden on another page. *Rescan the folder* means *put my library straight*, and a missing entry belongs to that as much as an added file does.

It runs **after** the registration, so games added by the same click get their entries too, and its count joins the result line — *"3 jeux ajoutés · 12 fiches complétées"* — rather than needing a sentence of its own. A failure is swallowed: it is not why the button was pressed, and the rescan has already done the work that was.

The profile's Library card held nothing else, so it goes, and with it the four strings only it used. `metadataFilled` replaces them, short enough to sit in a `·`-joined line.

## Testing

- `bun run test:all` — 130 + 20 + 960 + 385, all green. Full e2e on a fresh database: **52/52**. `svelte-check` 0 errors, frontend build clean.
- Rendered: the saves panel's two buttons now match their neighbour; the profile lists *Contrôles, Affichage, Langue, Ma configuration, Mes sauvegardes* — no *Bibliothèque*.
- Called for real: `POST /api/games/refresh-metadata` answers `{success, total, updated, skipped}`, which is the shape the new code reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
