### PR TITLE
Harmoniser les boutons sur la forme moulée

### DIFF
--- a/frontend/src/lib/components/FriendsList.svelte
+++ b/frontend/src/lib/components/FriendsList.svelte
@@ -480,15 +480,19 @@
     font-size: 1.25rem;
   }
 
+  /* Le dégradé violet qui était ici ne correspondait à rien dans
+     l'application - c'était le tell générique que la reprise a chassé
+     partout ailleurs. La forme vient maintenant du plancher ; il ne reste
+     que la couleur et le fait que ce bouton-là est carré. */
   .btn-add {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border: none;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    cursor: pointer;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
+    width: 34px;
+    height: 34px;
+    padding: 0;
     font-size: 1.25rem;
+    line-height: 1;
   }
 
   .add-friend {
@@ -597,22 +601,21 @@
     margin-bottom: 0.5rem;
   }
 
+  /* Accepter et refuser : les deux verbes du monde, et les deux couleurs
+     qui les portent partout ailleurs. Un vert et un rouge inventés sur
+     place les rendaient étrangers à leur propre application. */
   .btn-accept {
-    background: #4caf50;
-    color: white;
-    border: none;
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    cursor: pointer;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
+    padding: 0.15rem 0.6rem;
   }
 
   .btn-reject {
-    background: #f44336;
-    color: white;
-    border: none;
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    cursor: pointer;
+    background: var(--stop);
+    border-color: var(--stop-deep);
+    color: #ffffff;
+    padding: 0.15rem 0.6rem;
   }
 
   .friends-list {
@@ -646,14 +649,11 @@
 
   .btn-invite-friend {
     flex: 0 0 auto;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: #fff;
-    border: none;
-    padding: 0.375rem 0.75rem;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.8125rem;
-    font-weight: 600;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
+    font-size: 0.95rem;
+    padding: 0.2rem 0.7rem;
   }
 
   .btn-invite-friend.cancel {

--- a/frontend/src/lib/components/TopBar.svelte
+++ b/frontend/src/lib/components/TopBar.svelte
@@ -438,10 +438,25 @@
     }
   }
 
+  /*
+   * Enfoncée, et non allumée.
+   *
+   * Cet état avait d'abord été peint en vert. C'était une faute de
+   * vocabulaire : dans cette palette le vert veut dire « on avance », et
+   * un tiroir ouvert n'est pas une action en cours - c'est un état. Le
+   * dépenser là aurait rendu le vert muet ailleurs.
+   *
+   * Une touche moulée dit son état par son relief : le biseau s'inverse,
+   * sombre en haut et clair en bas, et le bouton s'enfonce d'un pixel.
+   * Seul, c'était juste mais trop discret à cette taille - d'où le libellé
+   * qui passe à l'or. L'or est l'accent du HUD, pas un verbe : il ne dit
+   * ni « avance » ni « annule », donc l'emprunter pour dire « ouvert » ne
+   * coûte rien au vert ni au rouge.
+   */
   .bar-button.on {
-    background: var(--go);
-    border-color: var(--go-deep);
-    color: #ffffff;
+    box-shadow: inset 0 4px 0 rgba(0, 0, 0, 0.4), inset 0 -4px 0 rgba(255, 255, 255, 0.08);
+    color: var(--edge);
+    transform: translateY(1px);
   }
 
   /* A link that has to read as a control, so it borrows the shape of the one

--- a/frontend/src/lib/components/TopBar.svelte
+++ b/frontend/src/lib/components/TopBar.svelte
@@ -396,19 +396,24 @@
     gap: 0.75rem;
   }
 
-  /* La touche du HUD : sombre, cerclée d'or, moulée. La recette est écrite
-     en entier ici et non héritée, parce que cette classe habille aussi des
-     <a> - le lien de retour et celui du profil - que le plancher de
-     `:global(button)` n'atteint pas. */
+  /* La touche du HUD : sombre, cerclée d'or, moulée.
+     Les valeurs de forme viennent des jetons et non d'une copie de la
+     recette - c'est cette copie, et sa dérive, qui faisait lire « Amis »
+     et « Rescanner le dossier » comme deux objets différents. La règle est
+     ici plutôt que dans le plancher parce qu'elle habille aussi des <a>,
+     que `:global(button)` n'atteint pas ; ce qu'elle ajoute à la forme
+     commune est sa couleur, et rien d'autre. */
   .bar-button {
+    display: inline-flex;
+    align-items: center;
     background: var(--ground);
-    border: 3px solid var(--edge);
-    box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.25), inset 0 4px 0 rgba(255, 255, 255, 0.12);
+    border: var(--btn-border) solid var(--edge);
+    box-shadow: var(--btn-bevel);
     color: var(--shell);
     font-family: var(--display);
-    font-size: 1.05rem;
-    padding: 0.25rem 0.8rem;
-    border-radius: 9px;
+    font-size: var(--btn-size);
+    padding: var(--btn-pad);
+    border-radius: var(--btn-radius);
     cursor: pointer;
   }
 

--- a/frontend/src/lib/components/TopBar.svelte
+++ b/frontend/src/lib/components/TopBar.svelte
@@ -396,18 +396,24 @@
     gap: 0.75rem;
   }
 
+  /* La touche du HUD : sombre, cerclée d'or, moulée. La recette est écrite
+     en entier ici et non héritée, parce que cette classe habille aussi des
+     <a> - le lien de retour et celui du profil - que le plancher de
+     `:global(button)` n'atteint pas. */
   .bar-button {
     background: var(--ground);
-    border: 1px solid var(--edge);
+    border: 3px solid var(--edge);
+    box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.25), inset 0 4px 0 rgba(255, 255, 255, 0.12);
     color: var(--shell);
-    padding: 0.35rem 0.7rem;
-    /* Angles à zéro : la barre appartient au même langage que les tuiles. */
-    border-radius: 0;
+    font-family: var(--display);
+    font-size: 1.05rem;
+    padding: 0.25rem 0.8rem;
+    border-radius: 9px;
     cursor: pointer;
   }
 
   .bar-button:hover {
-    border-color: var(--brand-lift);
+    background: var(--panel);
     color: var(--label);
   }
 
@@ -428,8 +434,9 @@
   }
 
   .bar-button.on {
-    background: #3a4a5a;
-    border-color: #667eea;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
   }
 
   /* A link that has to read as a control, so it borrows the shape of the one

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -322,14 +322,28 @@
    * de type (0,0,1) perd contre n'importe quelle classe (0,1,0), donc ceci
    * ne prend jamais le pas sur un style existant : il ne fait que garantir
    * qu'aucun bouton ne puisse plus jamais tomber sur le style par défaut.
+   *
+   * C'est aussi devenu le seul endroit où la FORME du bouton est écrite :
+   * le rayon, le biseau moulé, la police, l'épaisseur du bord. Un composant
+   * qui veut un bouton vert n'a donc plus qu'à poser deux couleurs, et tout
+   * ce qu'il ne redéclare pas retombe ici. Cette dissymétrie est voulue :
+   * la forme est commune à toute l'application, la couleur porte du sens -
+   * vert on avance, rouge on annule, sombre c'est de la navigation - et une
+   * application dont tous les boutons seraient verts aurait harmonisé la
+   * peinture en perdant l'information.
    */
   :global(button) {
-    font: inherit;
+    font-family: var(--display);
+    font-size: 1.05rem;
     color: var(--label);
     background: var(--panel);
-    border: 1px solid var(--edge);
-    border-radius: 0;
-    padding: 0.4rem 0.8rem;
+    border: 3px solid var(--edge);
+    border-radius: 9px;
+    /* Le biseau moulé : clair en haut, sombre en bas. C'est lui qui dit
+       « ceci s'enfonce », et c'est la seule partie de la recette qu'il
+       serait pénible de réécrire juste - donc elle ne se réécrit pas. */
+    box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.2), inset 0 4px 0 rgba(255, 255, 255, 0.27);
+    padding: 0.35rem 0.85rem;
     cursor: pointer;
   }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -303,6 +303,30 @@
        ligne. Le corps de texte long reste en sans système : aucune des deux
        n'est faite pour un paragraphe. */
     --display: 'Pixelify Sans', ui-sans-serif, system-ui, sans-serif;
+
+    /*
+     * La forme d'un bouton, et rien que sa forme.
+     *
+     * Elle vivait dans le plancher de `:global(button)`, ce qui suffisait
+     * tant que tous les boutons étaient des `<button>`. Deux ne le sont
+     * pas - « Amis » et « Retour à la bibliothèque » sont des `<a>`, que
+     * le plancher n'atteint pas - donc la recette y a été recopiée à la
+     * main, et les deux copies avaient déjà divergé : biseau à 0,25/0,12
+     * d'un côté et 0,2/0,27 de l'autre, marges et corps différents. Deux
+     * boutons voisins ne se lisaient plus comme le même objet.
+     *
+     * D'où ces jetons. Les valeurs n'existent qu'ici ; le plancher les
+     * applique, les règles qui habillent un `<a>` les appliquent aussi, et
+     * aucune des deux ne peut plus dériver de l'autre.
+     */
+    --btn-border: 3px;
+    --btn-radius: 9px;
+    --btn-pad: 0.35rem 0.85rem;
+    --btn-size: 1.05rem;
+    /* Clair en haut, sombre en bas : c'est ce relief qui dit « ceci
+       s'enfonce », et la seule partie de la recette qu'il serait pénible
+       de réécrire juste. */
+    --btn-bevel: inset 0 -4px 0 rgba(0, 0, 0, 0.2), inset 0 4px 0 rgba(255, 255, 255, 0.27);
   }
 
   :global(body) {
@@ -323,10 +347,10 @@
    * ne prend jamais le pas sur un style existant : il ne fait que garantir
    * qu'aucun bouton ne puisse plus jamais tomber sur le style par défaut.
    *
-   * C'est aussi devenu le seul endroit où la FORME du bouton est écrite :
-   * le rayon, le biseau moulé, la police, l'épaisseur du bord. Un composant
-   * qui veut un bouton vert n'a donc plus qu'à poser deux couleurs, et tout
-   * ce qu'il ne redéclare pas retombe ici. Cette dissymétrie est voulue :
+   * Il applique la forme déclarée plus haut en jetons, sans la redéfinir.
+   * Un composant qui veut un bouton vert n'a donc qu'à poser deux couleurs,
+   * et tout ce qu'il ne redéclare pas retombe ici. Cette dissymétrie est
+   * voulue :
    * la forme est commune à toute l'application, la couleur porte du sens -
    * vert on avance, rouge on annule, sombre c'est de la navigation - et une
    * application dont tous les boutons seraient verts aurait harmonisé la
@@ -334,16 +358,13 @@
    */
   :global(button) {
     font-family: var(--display);
-    font-size: 1.05rem;
+    font-size: var(--btn-size);
     color: var(--label);
     background: var(--panel);
-    border: 3px solid var(--edge);
-    border-radius: 9px;
-    /* Le biseau moulé : clair en haut, sombre en bas. C'est lui qui dit
-       « ceci s'enfonce », et c'est la seule partie de la recette qu'il
-       serait pénible de réécrire juste - donc elle ne se réécrit pas. */
-    box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.2), inset 0 4px 0 rgba(255, 255, 255, 0.27);
-    padding: 0.35rem 0.85rem;
+    border: var(--btn-border) solid var(--edge);
+    border-radius: var(--btn-radius);
+    box-shadow: var(--btn-bevel);
+    padding: var(--btn-pad);
     cursor: pointer;
   }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1031,18 +1031,17 @@
   /* Le tuyau vert : bord foncé, biseau clair en haut, ombre interne en bas.
      Deux `inset` suffisent à donner le moulé - c'est ce relief qui dit
      « ceci s'enfonce », que le rectangle gris ne disait pas. */
+  /* Le bouton dont tous les autres ont pris la forme. Il ne répète donc
+     plus le biseau, le rayon ni la police : tout cela est dans le plancher
+     de `:global(button)`, et il ne reste ici que sa couleur et sa mise en
+     ligne avec son icône. */
   .rescan {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
     background: var(--go);
+    border-color: var(--go-deep);
     color: #ffffff;
-    border: 3px solid var(--go-deep);
-    box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.2), inset 0 4px 0 rgba(255, 255, 255, 0.27);
-    padding: 0.4rem 0.85rem;
-    border-radius: 9px;
-    cursor: pointer;
-    font-family: var(--display);
     font-size: 1.1rem;
     flex-shrink: 0;
   }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1042,7 +1042,6 @@
     background: var(--go);
     border-color: var(--go-deep);
     color: #ffffff;
-    font-size: 1.1rem;
     flex-shrink: 0;
   }
 

--- a/frontend/src/routes/room/[id]/+page.svelte
+++ b/frontend/src/routes/room/[id]/+page.svelte
@@ -1260,13 +1260,20 @@
     opacity: 0.5;
   }
 
+  /* Un <a>, que le plancher de `:global(button)` n'atteint pas : la
+     recette moulée est donc écrite ici. Sombre et non verte - retourner à
+     la bibliothèque est de la navigation, pas l'action de cet écran. */
   .btn-leave {
-    background: #333;
-    color: white;
-    border: none;
-    padding: 1rem 2rem;
-    font-size: 1.125rem;
-    border-radius: 8px;
+    display: inline-block;
+    background: var(--panel);
+    border: 3px solid var(--edge);
+    box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.25), inset 0 4px 0 rgba(255, 255, 255, 0.12);
+    color: var(--shell);
+    font-family: var(--display);
+    font-size: 1.1rem;
+    padding: 0.5rem 1.4rem;
+    border-radius: 9px;
+    text-decoration: none;
     cursor: pointer;
   }
 

--- a/frontend/src/routes/room/[id]/+page.svelte
+++ b/frontend/src/routes/room/[id]/+page.svelte
@@ -1266,13 +1266,13 @@
   .btn-leave {
     display: inline-block;
     background: var(--panel);
-    border: 3px solid var(--edge);
-    box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.25), inset 0 4px 0 rgba(255, 255, 255, 0.12);
+    border: var(--btn-border) solid var(--edge);
+    box-shadow: var(--btn-bevel);
     color: var(--shell);
     font-family: var(--display);
-    font-size: 1.1rem;
-    padding: 0.5rem 1.4rem;
-    border-radius: 9px;
+    font-size: var(--btn-size);
+    padding: var(--btn-pad);
+    border-radius: var(--btn-radius);
     text-decoration: none;
     cursor: pointer;
   }


### PR DESCRIPTION
« Rescanner le dossier » était le seul bouton à porter le monde dans lequel il vit. Partout ailleurs c'était plat : un rectangle gris dans la barre, un pavé `#333` pour « Retour à la bibliothèque », un vert et un rouge inventés sur place pour accepter et refuser, et — sur « + » et « Inviter » — le dégradé violet générique que toute cette reprise a chassé, une couleur qui ne correspond à rien dans l'application.

## La forme monte dans le plancher, la couleur garde son sens

La forme est commune à toute l'application ; la couleur porte de l'information. **Vert on avance, rouge on annule, sombre c'est de la navigation.** Une application dont tous les boutons seraient verts aurait harmonisé la peinture en jetant l'information — c'est la réponse facile à « fais-les se ressembler », et la mauvaise.

Le plancher `:global(button)` existait déjà pour empêcher un bouton de retomber sur le rectangle blanc du navigateur. Il applique maintenant aussi la forme, donc un composant qui veut un bouton vert pose deux couleurs et hérite du reste. Un sélecteur de type perd contre n'importe quelle classe, donc rien de ce qui se style lui-même n'est écrasé.

## Deux corrections dues à l'œil du propriétaire, pas à une vérification

**`b3a9bfd` — « Amis » et « Rescanner le dossier » ne se lisaient pas comme le même objet.** Ils ne l'étaient pas. Deux boutons ne sont pas des `<button>` — « Amis » et « Retour à la bibliothèque » sont des `<a>`, que le plancher n'atteint pas — donc la recette y avait été recopiée à la main, et les copies avaient déjà divergé : biseau à 0,25/0,12 contre 0,2/0,27, marges et corps différents. Les valeurs n'existent plus qu'une fois, en jetons (`--btn-border`, `--btn-radius`, `--btn-pad`, `--btn-size`, `--btn-bevel`).

Mesuré sur les deux après correction :

```
AMIS    h=37  radius=9px  border=3px  pad=5.6/13.6  16.8px Pixelify  bevel=0.2/0.27
RESCAN  h=37  radius=9px  border=3px  pad=5.6/13.6  16.8px Pixelify  bevel=0.2/0.27
```

**`050d6a4` — le tiroir ouvert passait « Amis » au vert.** Mauvais mot : le vert dit « ceci fait avancer », et un tiroir ouvert est un état. Une touche moulée dit son état par son relief — le biseau s'inverse, le bouton s'enfonce d'un pixel — et le libellé passe à l'or, qui est l'accent du HUD et non un verbe.

## Vérification

- `svelte-check` 0 erreur
- e2e **52/52** sur base réinitialisée
- build frontend propre

🤖 Generated with [Claude Code](https://claude.com/claude-code)