### PR TITLE
Finir le tour des boutons, et plier la barre pour un téléphone

### DIFF
--- a/core/test/shelves.test.ts
+++ b/core/test/shelves.test.ts
@@ -14,7 +14,7 @@
 import { test } from 'bun:test';
 import assert from 'node:assert/strict';
 
-import { columnsThatFit, rowBottoms } from '../../frontend/src/lib/games/shelves.js';
+import { columnsThatFit, rowBottoms, trackWidth } from '../../frontend/src/lib/games/shelves.js';
 
 const CARD = 376;
 const GAP = 28;
@@ -70,4 +70,14 @@ test('les planches sont espacées du pas d une rangée', () => {
 
 test('une seule rangée donne une seule planche, au bas de la rangée', () => {
 	assert.deepEqual(rowBottoms({ count: 2, columns: 3, rowHeight: 263, rowGap: 56 }), [263]);
+});
+
+test('une piste garde son format tant qu il tient, et cède ensuite', () => {
+	// Le miroir de `min(var(--card-w), 100%)`. C'est de cette largeur que se
+	// déduit la hauteur de rangée, donc la position des planches : la prendre
+	// pour 376 sur un téléphone de 320 les ferait passer dans les jaquettes.
+	assert.equal(trackWidth(1216, CARD), CARD);
+	assert.equal(trackWidth(CARD, CARD), CARD);
+	assert.equal(trackWidth(326, CARD), 326);
+	assert.equal(trackWidth(0, CARD), 0);
 });

--- a/core/test/way-back.test.ts
+++ b/core/test/way-back.test.ts
@@ -30,6 +30,14 @@ test('the profile screen gets a labelled link home - the finding that prompted t
 	assert.deepEqual(wayBack('/profile'), { href: '/', label: 'backToLibrary' });
 });
 
+test('the documentation gets one too, since the brand that was its only way home is gone', () => {
+	// La barre portait un logo qui menait à `/`. Il a été retiré, et /docs
+	// n'avait que lui : sans cette entrée, on lit la documentation et on ne
+	// peut plus en sortir autrement qu'avec le bouton du navigateur.
+	assert.deepEqual(wayBack('/docs'), { href: '/', label: 'backToLibrary' });
+	assert.deepEqual(wayBack('/docs/'), { href: '/', label: 'backToLibrary' });
+});
+
 test('a trailing slash is the same screen', () => {
 	assert.deepEqual(wayBack('/profile/'), { href: '/', label: 'backToLibrary' });
 	assert.equal(wayBack(''), null);

--- a/e2e/narrow-bar.spec.ts
+++ b/e2e/narrow-bar.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * La barre en largeur de téléphone.
+ *
+ * Ce que ces tests gardent est une mesure, pas une impression : le contenu
+ * de la barre faisait 393 px de large, donc sur un écran de 390 la page se
+ * mettait à défiler latéralement et la marque était rognée en un trait.
+ * Rien dans la suite ne voyait ça - on peut cliquer tous les boutons d'une
+ * page qui déborde.
+ *
+ * `document.scrollWidth` est la mesure juste : elle vaut la largeur de la
+ * fenêtre quand rien ne dépasse, et davantage dès que quelque chose sort.
+ * Elle attrape aussi bien la barre que la page en dessous, ce qui a servi -
+ * le bloc d'identité du profil débordait pour une raison entièrement
+ * différente, et c'est ce chiffre qui l'a dit.
+ */
+
+import { test, expect } from '@playwright/test';
+import { loginDev, apiFetch, keepRomOnDevice } from './helpers';
+
+const PHONES = [430, 390, 360, 320];
+
+test.describe('la barre sur un écran étroit', () => {
+	test('aucune page ne déborde en largeur de téléphone', async ({ page, context }) => {
+		const cookie = await loginDev('1');
+		await context.addCookies(
+			cookie.split('; ').map(pair => {
+				const [name, ...rest] = pair.split('=');
+				return { name, value: rest.join('='), domain: 'localhost', path: '/' };
+			})
+		);
+		await page.goto('/');
+		const res = await apiFetch(cookie, '/api/games', {
+			method: 'POST',
+			body: JSON.stringify({ checksum: 'FE000001', filename: 'Chrono Trigger (USA).sfc' })
+		});
+		await keepRomOnDevice(page, (await res.json()).crc32);
+
+		for (const width of PHONES) {
+			await page.setViewportSize({ width, height: 780 });
+			for (const route of ['/', '/profile', '/docs']) {
+				await page.goto(route);
+				await page.waitForLoadState('networkidle');
+				const overflow = await page.evaluate(() => document.documentElement.scrollWidth);
+				expect(overflow, `${route} à ${width}px`).toBeLessThanOrEqual(width);
+			}
+		}
+	});
+
+	test('la loupe ouvre la recherche, et la refermer efface la requête', async ({ page, context }) => {
+		const cookie = await loginDev('1');
+		await context.addCookies(
+			cookie.split('; ').map(pair => {
+				const [name, ...rest] = pair.split('=');
+				return { name, value: rest.join('='), domain: 'localhost', path: '/' };
+			})
+		);
+		await page.goto('/');
+		for (const [i, title] of ['Chrono Trigger (USA)', 'Super Mario Kart (Europe)'].entries()) {
+			const res = await apiFetch(cookie, '/api/games', {
+				method: 'POST',
+				body: JSON.stringify({
+					checksum: (0xfe100000 + i).toString(16).toUpperCase(),
+					filename: `${title}.sfc`
+				})
+			});
+			await keepRomOnDevice(page, (await res.json()).crc32);
+		}
+
+		await page.setViewportSize({ width: 390, height: 780 });
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+		await expect(page.locator('.game-card')).toHaveCount(2);
+
+		// Repliée, la recherche n'est pas à l'écran : c'est la loupe qui l'est.
+		await expect(page.locator('.library-search')).toBeHidden();
+		await page.locator('.search-toggle').click();
+
+		// Le focus vient avec l'ouverture : sans lui, taper demanderait deux
+		// appuis, et c'est le genre de détail qu'on ne remarque qu'à l'usage.
+		await expect(page.locator('.library-search')).toBeFocused();
+		// La barre n'a plus la place pour autre chose, et le dit.
+		await expect(page.locator('.friends')).toBeHidden();
+
+		await page.locator('.library-search').fill('mario');
+		await expect(page.locator('.game-card')).toHaveCount(1);
+
+		await page.keyboard.press('Escape');
+		// Refermer efface : une bibliothèque filtrée sans champ visible serait
+		// un mode caché, et personne ne saurait pourquoi il manque des jeux.
+		await expect(page.locator('.game-card')).toHaveCount(2);
+		await expect(page.locator('.search-toggle')).toBeVisible();
+	});
+});

--- a/e2e/narrow-bar.spec.ts
+++ b/e2e/narrow-bar.spec.ts
@@ -46,7 +46,7 @@ test.describe('la barre sur un écran étroit', () => {
 		}
 	});
 
-	test('la loupe ouvre la recherche, et la refermer efface la requête', async ({ page, context }) => {
+	test('le champ prend la barre quand on y entre, et la refermer efface la requête', async ({ page, context }) => {
 		const cookie = await loginDev('1');
 		await context.addCookies(
 			cookie.split('; ').map(pair => {
@@ -71,23 +71,28 @@ test.describe('la barre sur un écran étroit', () => {
 		await page.waitForLoadState('networkidle');
 		await expect(page.locator('.game-card')).toHaveCount(2);
 
-		// Repliée, la recherche n'est pas à l'écran : c'est la loupe qui l'est.
-		await expect(page.locator('.library-search')).toBeHidden();
-		await page.locator('.search-toggle').click();
+		// Le champ est là tout le temps, et il prend toute la place que les
+		// autres ne prennent pas - il avait d'abord été réduit à la largeur de
+		// sa loupe, ce qui en faisait un bouton déguisé avec 250 px de vide à
+		// côté.
+		const field = page.locator('.library-search');
+		await expect(field).toBeVisible();
+		const collapsed = (await field.boundingBox())!.width;
+		expect(collapsed).toBeGreaterThan(150);
 
-		// Le focus vient avec l'ouverture : sans lui, taper demanderait deux
-		// appuis, et c'est le genre de détail qu'on ne remarque qu'à l'usage.
-		await expect(page.locator('.library-search')).toBeFocused();
-		// La barre n'a plus la place pour autre chose, et le dit.
+		await field.click();
+		// Entrer dedans efface le reste de la barre, donc il gagne leur place.
 		await expect(page.locator('.friends')).toBeHidden();
+		expect((await field.boundingBox())!.width).toBeGreaterThan(collapsed);
 
-		await page.locator('.library-search').fill('mario');
+		await field.fill('mario');
 		await expect(page.locator('.game-card')).toHaveCount(1);
 
 		await page.keyboard.press('Escape');
 		// Refermer efface : une bibliothèque filtrée sans champ visible serait
 		// un mode caché, et personne ne saurait pourquoi il manque des jeux.
 		await expect(page.locator('.game-card')).toHaveCount(2);
-		await expect(page.locator('.search-toggle')).toBeVisible();
+		// Et la barre rend leur place à Amis et à l'avatar.
+		await expect(page.locator('.friends')).toBeVisible();
 	});
 });

--- a/e2e/pseudo-gate.spec.ts
+++ b/e2e/pseudo-gate.spec.ts
@@ -105,6 +105,16 @@ test.describe('the onboarding gate', () => {
   test('the profile shows the code that replaced the email', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('button', { name: /Dev User 1/ }).click();
+    /*
+     * Attendre que la connexion ait abouti avant de naviguer.
+     *
+     * Le clic lance un aller-retour réseau qui pose le cookie ; `goto` ne
+     * l'attend pas. Deux fois - le 2026-09-10 et le 2026-09-11 - ce test a
+     * échoué en affichant la page de connexion à `/profile`, et il repassait
+     * seul, ce qui est exactement la forme d'une course. La barre n'existe
+     * que pour quelqu'un de connecté : l'attendre, c'est attendre le cookie.
+     */
+    await expect(page.locator('.top-bar')).toBeVisible();
     await page.goto('/profile');
 
     await expect(page.getByText('DevOne#0001')).toBeVisible();

--- a/e2e/top-bar.spec.ts
+++ b/e2e/top-bar.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Le retour que la barre offre depuis un salon.
+ *
+ * Ce qui est gardé ici n'est pas l'apparence mais la NATURE du contrôle.
+ * `way-back.ts` exclut le salon de sa liste, et dit pourquoi : quitter un
+ * salon détache le jeu, rend le siège quand on est seul et oublie le salon
+ * mémorisé, avant de naviguer. Un `<a href="/">` ne ferait rien de tout
+ * cela et ramènerait le joueur à la bibliothèque encore assis dans un salon
+ * que le serveur croit occupé.
+ *
+ * D'où l'assertion sur le nom de la balise, qui a l'air d'un détail et est
+ * exactement la différence entre le contrôle voulu et le bug : les deux
+ * mènent à `/`, un seul libère le siège.
+ */
+
+import { test, expect } from '@playwright/test';
+import { loginDev, connectSocket, createRoom } from './helpers';
+
+test('le retour depuis un salon emprunte l action de la page, pas un lien', async ({
+	page,
+	context
+}) => {
+	const cookie = await loginDev('1');
+	await context.addCookies(
+		cookie.split('; ').map(pair => {
+			const [name, ...rest] = pair.split('=');
+			return { name, value: rest.join('='), domain: 'localhost', path: '/' };
+		})
+	);
+
+	const connection = await connectSocket(cookie);
+	const socket = (connection as any).socket ?? connection;
+	const room: any = await createRoom(socket, 'Chrono Trigger');
+	const roomId = room?.id ?? room?.roomId ?? room;
+
+	try {
+		await page.goto(`/room/${roomId}`);
+		const arrow = page.locator('.back.arrow');
+		await expect(arrow).toBeVisible();
+
+		// Une flèche seule, donc le nom vit dans l'étiquette accessible : sans
+		// elle, ce bouton s'appellerait « » pour un lecteur d'écran.
+		await expect(arrow).toHaveAttribute('aria-label', /.+/);
+
+		// Le point entier de ce test.
+		expect(await arrow.evaluate(el => el.tagName)).toBe('BUTTON');
+		expect(await arrow.evaluate(el => el.getAttribute('href'))).toBeNull();
+
+		await arrow.click();
+		await expect(page).toHaveURL(/\/$/);
+	} finally {
+		socket?.close?.();
+	}
+});

--- a/frontend/src/lib/components/AnonymousJoin.svelte
+++ b/frontend/src/lib/components/AnonymousJoin.svelte
@@ -175,15 +175,12 @@
     border-color: #e2565c;
   }
 
+  /* Rejoindre, donc vert. */
   button {
-    padding: 0.8rem 1rem;
-    border: 0;
-    border-radius: 0.5rem;
-    background: #667eea;
-    color: #fff;
-    font-size: 1rem;
-    font-weight: 600;
-    cursor: pointer;
+    padding: 0.55rem 1rem;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
   }
 
   button:disabled {

--- a/frontend/src/lib/components/ConfirmModal.svelte
+++ b/frontend/src/lib/components/ConfirmModal.svelte
@@ -140,19 +140,20 @@
     transform: translateY(0);
   }
 
+  /* Rien à dire de plus que le plancher : renoncer est l'option neutre. */
   .btn-secondary {
-    background: var(--bg-tertiary, #2a2a2a);
-    color: var(--text-primary, #fff);
-    border: 1px solid var(--border-color, #444);
+    background: var(--panel);
   }
 
   .btn-secondary:hover {
-    background: var(--bg-hover, #333);
+    background: var(--edge);
+    color: var(--panel);
   }
 
   .btn-primary {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
   }
 
   .btn-primary:hover {

--- a/frontend/src/lib/components/ControlsSettings.svelte
+++ b/frontend/src/lib/components/ControlsSettings.svelte
@@ -363,12 +363,13 @@
 
   .tabs button,
   .actions button {
-    background: #333;
-    color: #eee;
-    border: 1px solid #555;
-    border-radius: 6px;
-    padding: 0.45rem 0.9rem;
-    font-size: 0.9rem;
+    background: var(--ground);
+    color: var(--shell);
+    border: var(--btn-border) solid var(--edge);
+    border-radius: var(--btn-radius);
+    box-shadow: var(--btn-bevel);
+    padding: 0.25rem 0.9rem;
+    font-size: 0.95rem;
     cursor: pointer;
   }
 

--- a/frontend/src/lib/components/FriendDetailsModal.svelte
+++ b/frontend/src/lib/components/FriendDetailsModal.svelte
@@ -255,15 +255,13 @@
     justify-content: center;
   }
 
+  /* Retirer un ami détruit quelque chose : rouge, comme partout. */
   .btn-remove {
-    background: #f44336;
-    color: white;
-    border: none;
-    padding: 0.75rem 2rem;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 1rem;
-    transition: all 0.2s;
+    background: var(--stop);
+    border-color: var(--stop-deep);
+    color: #ffffff;
+    padding: 0.55rem 1.6rem;
+    transition: background 0.2s;
   }
 
   .btn-remove:hover {

--- a/frontend/src/lib/components/InvitationCard.svelte
+++ b/frontend/src/lib/components/InvitationCard.svelte
@@ -205,8 +205,9 @@
   }
 
   .accept {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: #fff;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
   }
 
   .decline {

--- a/frontend/src/lib/components/LanguageSelector.svelte
+++ b/frontend/src/lib/components/LanguageSelector.svelte
@@ -36,40 +36,35 @@
 <style>
   .language-selector {
     display: inline-flex;
-    padding: 0.2rem;
-    gap: 0.2rem;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 10px;
+    padding: 0.25rem;
+    gap: 0.25rem;
+    background: var(--panel);
+    border: 2px solid var(--edge);
+    border-radius: 12px;
   }
 
+  /* Un segment de choix, pas une action : il ne prend ni le vert ni le
+     rouge, et son état actif se dit comme celui de la barre - enfoncé, et
+     l'or pour libellé. */
   .choice {
     background: transparent;
     border: none;
+    box-shadow: none;
     border-radius: 8px;
-    padding: 0.45rem 0.9rem;
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: #aaa;
-    cursor: pointer;
+    padding: 0.15rem 0.9rem;
+    color: var(--muted);
     transition:
       background 0.15s,
       color 0.15s;
   }
 
   .choice:hover:not(.on) {
-    background: rgba(255, 255, 255, 0.06);
-    color: #ddd;
+    color: var(--shell);
   }
 
   .choice.on {
-    /* Pas le #667eea de la marque : sous du blanc à 14.4px il donne 3.66:1, là
-       où AA en demande 4.5. Même teinte (229°), assombrie jusqu'à 4.96:1 -
-       assez de marge pour que l'arrondi d'un moteur de rendu ne la repasse pas
-       sous le seuil. Le dégradé des boutons garde son #667eea : axe ne mesure
-       pas un fond dégradé, et le changer ici seul suffit à ce que le choix
-       actif se lise. */
-    background: #4764e6;
-    color: #fff;
+    background: var(--ground);
+    box-shadow: inset 0 4px 0 rgba(0, 0, 0, 0.4), inset 0 -4px 0 rgba(255, 255, 255, 0.08);
+    color: var(--edge);
   }
 </style>

--- a/frontend/src/lib/components/PauseMenu.svelte
+++ b/frontend/src/lib/components/PauseMenu.svelte
@@ -690,20 +690,14 @@
   }
 
   .menu-items button {
-    background: #444;
-    color: white;
-    border: 2px solid transparent;
-    padding: 1rem;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 1rem;
-    transition: all 0.2s;
+    padding: 0.7rem 1rem;
+    transition: background 0.2s, transform 0.2s;
   }
 
   .menu-items button:hover,
   .menu-items button.selected {
-    background: #555;
-    border: 2px solid #667eea;
+    background: var(--edge);
+    color: var(--panel);
     transform: translateX(8px);
   }
 
@@ -765,15 +759,9 @@
   }
 
   .nudge {
-    background: #444;
-    color: #fff;
-    border: 2px solid transparent;
-    border-radius: 8px;
     width: 2.75rem;
-    padding: 0.6rem 0;
-    font-size: 1.1rem;
+    padding: 0.35rem 0;
     line-height: 1;
-    cursor: pointer;
   }
 
   .nudge:hover:not(:disabled),
@@ -789,13 +777,7 @@
 
   .back-button {
     margin-top: 1rem;
-    background: #444;
-    color: white;
-    border: none;
-    padding: 0.75rem 1.5rem;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 1rem;
+    padding: 0.55rem 1.5rem;
     width: 100%;
   }
 

--- a/frontend/src/lib/components/PlayerControls.svelte
+++ b/frontend/src/lib/components/PlayerControls.svelte
@@ -543,15 +543,20 @@
     color: #ccc;
   }
 
+  /* Le `<select>` est dans le lot, et le plancher ne l'atteint pas : la
+     recette est donc écrite ici, mais tirée des jetons plutôt que recopiée -
+     c'est la divergence entre deux copies qui avait déjà été corrigée une
+     fois dans la barre. */
   .sources select,
   .sources button,
   .actions button {
-    background: #333;
-    color: #eee;
-    border: 1px solid #555;
-    border-radius: 6px;
-    padding: 0.35rem 0.7rem;
-    font-size: 0.85rem;
+    background: var(--ground);
+    color: var(--shell);
+    border: var(--btn-border) solid var(--edge);
+    border-radius: var(--btn-radius);
+    box-shadow: var(--btn-bevel);
+    padding: 0.2rem 0.7rem;
+    font-size: 0.9rem;
     cursor: pointer;
   }
 

--- a/frontend/src/lib/components/RomSourcePanel.svelte
+++ b/frontend/src/lib/components/RomSourcePanel.svelte
@@ -283,14 +283,11 @@
     line-height: 1.4;
   }
 
-  button {
-    background: #333;
-    border: 2px solid transparent;
-    color: #fff;
-    padding: 0.4rem 0.75rem;
-    border-radius: 6px;
-    cursor: pointer;
-  }
+  /* Plus de règle de forme ici : celle-ci écrasait le plancher sans le
+     vouloir. Une règle `button` écrite DANS un composant porte la classe de
+     portée de Svelte, donc sa spécificité (0,1,1) bat celle du plancher
+     (0,0,1) - et ce panneau restait à l'ancien langage alors que le reste
+     de l'application avait changé. Ce qu'il n'a plus à dire, il l'hérite. */
 
   button:disabled {
     opacity: 0.5;

--- a/frontend/src/lib/components/RoomPlayers.svelte
+++ b/frontend/src/lib/components/RoomPlayers.svelte
@@ -186,8 +186,8 @@
   /* Always on screen, never hover-only: a hover affordance does not exist on
      a touch screen, which is where this was least discoverable. */
   .slot-action {
-    font-size: 0.8rem;
-    color: #667eea;
+    font-size: 0.9rem;
+    color: var(--edge);
   }
 
   .player:hover:not(:disabled) .slot-action {

--- a/frontend/src/lib/components/SaveGameMenu.svelte
+++ b/frontend/src/lib/components/SaveGameMenu.svelte
@@ -135,13 +135,10 @@
   }
 
   .btn-new {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.875rem;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
+    font-size: 0.95rem;
   }
 
   .btn-new:disabled {

--- a/frontend/src/lib/components/SaveGrid.svelte
+++ b/frontend/src/lib/components/SaveGrid.svelte
@@ -328,7 +328,7 @@
 
   .action {
     flex: 0 0 auto;
-    color: #667eea;
+    color: var(--edge);
     font-size: 0.8125rem;
     text-transform: uppercase;
     letter-spacing: 0.03em;
@@ -401,13 +401,7 @@
   .btn-retry {
     display: block;
     margin: 0.75rem auto 0;
-    background: #444;
-    color: white;
-    border: none;
-    padding: 0.4rem 0.9rem;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: 0.95rem;
   }
 
   .btn-retry:hover {

--- a/frontend/src/lib/components/SavesPortabilityPanel.svelte
+++ b/frontend/src/lib/components/SavesPortabilityPanel.svelte
@@ -148,14 +148,11 @@
      tout - donc le bouton brut du navigateur, blanc et carré, à côté de son
      voisin habillé. Signalé le 2026-09-10 : « ya plein de boutons sans style
      comme Télécharger mes sauvegardes ». */
-  button {
-    background: #333;
-    border: 2px solid transparent;
-    color: #fff;
-    padding: 0.4rem 0.75rem;
-    border-radius: 6px;
-    cursor: pointer;
-  }
+  /* Plus de règle de forme ici : celle-ci écrasait le plancher sans le
+     vouloir. Une règle `button` écrite DANS un composant porte la classe de
+     portée de Svelte, donc sa spécificité (0,1,1) bat celle du plancher
+     (0,0,1) - et ce panneau restait à l'ancien langage alors que le reste
+     de l'application avait changé. Ce qu'il n'a plus à dire, il l'hérite. */
 
   button:disabled {
     opacity: 0.5;

--- a/frontend/src/lib/components/SoloRoom.svelte
+++ b/frontend/src/lib/components/SoloRoom.svelte
@@ -1118,12 +1118,7 @@
   }
 
   .action {
-    background: #333;
-    border: 2px solid transparent;
-    color: #fff;
-    padding: 0.4rem 0.75rem;
-    border-radius: 6px;
-    cursor: pointer;
+    padding: 0.35rem 0.85rem;
   }
 
   .action:disabled {

--- a/frontend/src/lib/components/TopBar.svelte
+++ b/frontend/src/lib/components/TopBar.svelte
@@ -41,9 +41,38 @@
    */
   let searching = false;
 
-  function openSearch() {
+  /*
+   * Ouvrir, c'est entrer dans le champ - il n'y a pas de bouton pour ça.
+   *
+   * Le champ ne disparaît jamais : sur écran étroit il se réduit à la
+   * largeur de sa loupe, qui est dessinée dans son propre fond. Un bouton
+   * séparé aurait été un objet de plus à comprendre pour ouvrir une chose
+   * qui était déjà là.
+   *
+   * `focusin` plutôt qu'un `on:focus` posé sur le champ : le champ
+   * appartient à la page, pas à la barre, et la barre n'a pas à le
+   * connaître pour savoir que le focus est entré chez elle.
+   */
+  function onFocusIn(event: FocusEvent) {
+    if (!(event.target as HTMLElement)?.closest?.('.page-tool')) return;
     searching = true;
     dispatch('searchopen');
+  }
+
+  /*
+   * Sortir du champ ne referme QUE s'il est vide.
+   *
+   * Refermer efface la requête ; le faire alors que le joueur vient de
+   * taper trois lettres et d'aller regarder sa grille lui reprendrait son
+   * filtre sans qu'il ait rien demandé. Mais laisser la barre dépliée sur
+   * un champ vide, c'est cacher Amis et l'avatar pour rien - un état dont
+   * on ne sort plus sans savoir qu'il faut cliquer la croix.
+   */
+  function onFocusOut(event: FocusEvent) {
+    const field = event.target as HTMLInputElement | null;
+    if (!field?.closest?.('.page-tool')) return;
+    if (field.value?.trim()) return;
+    closeSearch();
   }
 
   /*
@@ -275,32 +304,16 @@
 
 <svelte:window on:keydown={(e) => { if (e.key === 'Escape' && searching) closeSearch(); }} />
 
-<header class="top-bar" class:searching>
+<header class="top-bar" class:searching on:focusin={onFocusIn} on:focusout={onFocusOut}>
   <div class="left">
     <!--
-      The brand still goes home, because it always has and people who know that
-      convention keep using it. It is no longer the only thing that does.
+      Plus de marque ici. Elle menait à la bibliothèque, ce qu'une
+      convention du web fait sans l'annoncer - donc une affordance qui
+      n'en avait pas l'air, et le seul élément de cette barre qui ne
+      faisait rien qu'un autre ne fasse déjà. Les écrans qui ont besoin
+      d'un chemin de retour en ont un, nommé : `way-back.ts` dit lesquels
+      et pourquoi le salon n'en fait pas partie.
     -->
-    <!--
-      La vraie marque, et non une manette générique.
-      
-      C'était 🎮 + « PSNES » : un emoji qui n'est pas le logo de
-      l'application, et dont le rendu dépend de la police du système. La
-      La marque de `static/favicon.svg`, et non la cartouche entière de
-      `icon.svg` : ce fichier porte lui-même la règle - « below 48px the
-      shell cannot be both honest and legible » - et une barre fait 26 px.
-      Essayé avec la coque d'abord, illisible, exactement comme annoncé.
-
-      Le mot disparaît avec l'emoji : une marque qui se voit n'a pas besoin
-      d'être aussi épelée à côté.
-    -->
-    <a class="brand" class:redundant={!!back} href="/" aria-label="psnes">
-      <svg viewBox="0 0 32 32" width="26" height="26" aria-hidden="true">
-        <rect width="32" height="32" rx="5" fill="var(--brand)" />
-        <path d="M10 6H22V18H14V26H10ZM14 10H18V14H14Z" fill="var(--label)" fill-rule="evenodd" />
-      </svg>
-    </a>
-
     {#if back}
       <!--
         Said in words, and wearing the bar's own button shape: the whole finding
@@ -328,17 +341,9 @@
   </div>
 
   {#if $$slots.tool}
-    <!-- Rendus seulement si la page a mis quelque chose à replier : sur
-         /profile et /docs il n'y a pas de recherche, donc pas de loupe.
-         Le CSS les cache au-dessus du point de rupture ; ils n'existent
-         que pour l'écran étroit. -->
-    <button class="icon-button search-toggle" on:click={openSearch} title={t($language, 'searchLibrary')} aria-label={t($language, 'searchLibrary')}>
-      <svg viewBox="0 0 16 16" width="17" height="17" fill="none" stroke="currentColor"
-           stroke-width="2" stroke-linecap="round" aria-hidden="true">
-        <circle cx="7" cy="7" r="4.5" />
-        <path d="M10.5 10.5L14 14" />
-      </svg>
-    </button>
+    <!-- Rendue seulement si la page a mis quelque chose dans la barre, et
+         cachée au-dessus du point de rupture : elle n'existe que pour
+         refermer un champ qui a pris toute la place. -->
     <button class="icon-button search-close" on:click={closeSearch} title={t($language, 'close')} aria-label={t($language, 'close')}>
       <svg viewBox="0 0 16 16" width="17" height="17" fill="none" stroke="currentColor"
            stroke-width="2" stroke-linecap="round" aria-hidden="true">
@@ -370,12 +375,7 @@
           <path d="M12 10.6c-0.7 0-1.1-0.5-1.1-1.3s0.4-1.3 1.1-1.3 1.1 0.5 1.1 1.3-0.4 1.3-1.1 1.3z"
                 fill="currentColor" />
         </svg>
-        <span class="vr-label">{t($language, 'enterVr')}</span>
       </button>
-      <!-- Beside the button, not under it: this bar is a centred flex row and a
-           second line would change its height on every page. Only rendered
-           where the button is, so a PC with no headset never sees it. -->
-      <span class="vr-hint">{t($language, 'vrSeatedHint')}</span>
     {/if}
 
     <button
@@ -454,8 +454,36 @@
     cursor: pointer;
   }
 
+  /* Le casque est une icône à toutes les largeurs, et plus seulement sur
+     téléphone. Le bouton portait « Passer en VR » en toutes lettres à côté
+     du glyphe : deux fois la même chose, dans une barre qui manque de place
+     jusque sur un grand écran - et le dessin dit ce que le mot disait, ce
+     qui n'est pas vrai de tous les libellés (le retour, lui, garde les
+     siens, et le commentaire de `.back` dit pourquoi).
+     
+     Le nom reste dans `aria-label` et dans l'infobulle, et la phrase qui
+     explique le mode assis est toujours là, à côté, au-dessus de 640 px. */
   .vr-glyph {
-    display: none;
+    display: block;
+  }
+
+  /*
+   * Tous les glyphes de la barre font la hauteur d'une ligne de texte.
+   *
+   * Mesuré, et c'est la même faute qu'« Amis » contre « Rescanner » : un
+   * dessin de 16 px posé dans un bouton donne une boîte de 30 px de haut
+   * quand son voisin, qui contient un mot, en fait 37. Deux boutons côte à
+   * côte de hauteurs différentes ne se lisent pas comme le même objet.
+   *
+   * `1.25em` plutôt qu'une valeur en pixels : la hauteur suit alors le corps
+   * du bouton, qui vient de `--btn-size`, donc changer l'un ne peut plus
+   * désaccorder l'autre. La largeur se déduit du viewBox.
+   */
+  .vr-glyph,
+  .friends-glyph,
+  .icon-button svg {
+    height: 1.25em;
+    width: auto;
   }
 
   .top-bar {
@@ -481,19 +509,6 @@
     min-width: 0;
   }
 
-  .brand {
-    display: inline-flex;
-    align-items: center;
-    text-decoration: none;
-    /* La cible reste confortable alors que la marque a rétréci. */
-    padding: 0.25rem;
-  }
-
-  .brand:focus-visible {
-    outline: 2px solid var(--brand-lift);
-    outline-offset: 2px;
-  }
-
   .right {
     display: flex;
     align-items: center;
@@ -510,6 +525,10 @@
   .bar-button {
     display: inline-flex;
     align-items: center;
+    /* Explicite, et c'est ce qui met glyphes et mots à la même hauteur :
+       un dessin de 1,25em dans un bouton dont la boîte de ligne est
+       implicite donnait 38 px là où son voisin en faisait 37. */
+    line-height: 1.25;
     background: var(--ground);
     border: var(--btn-border) solid var(--edge);
     box-shadow: var(--btn-bevel);
@@ -524,22 +543,6 @@
   .bar-button:hover {
     background: var(--panel);
     color: var(--label);
-  }
-
-  /* Quiet on purpose: it is a caption for the button next to it, not a
-     control, and the bar already has enough things asking to be pressed. */
-  .vr-hint {
-    color: #8a8a98;
-    font-size: 0.78rem;
-    white-space: nowrap;
-  }
-
-  /* The bar is tight on a phone, and this is the one thing in it that is
-     advice rather than function - so it is the first thing to go. */
-  @media (max-width: 640px) {
-    .vr-hint {
-      display: none;
-    }
   }
 
   /*
@@ -627,25 +630,26 @@
    * autre ne fasse déjà.
    */
   @media (max-width: 480px) {
-    .brand {
-      display: none;
-    }
-
-    /* Le VR garde son icône et perd son mot. */
-    .vr-label {
-      display: none;
-    }
-
-    .vr-glyph {
-      display: block;
-    }
-
-    .page-tool {
-      display: none;
-    }
-
-    .search-toggle {
-      display: inline-flex;
+    /*
+     * Le champ prend tout ce qui reste, et jamais moins.
+     *
+     * Il avait d'abord été réduit à la largeur de sa loupe, ce qui en
+     * faisait un bouton déguisé : 46 px de champ sur une barre de 390, et
+     * 250 px de noir à côté qui ne servaient à rien. `flex: 1` le laisse
+     * absorber tout l'espace que les autres ne prennent pas, et `min-width`
+     * doit céder pour ça - c'est lui, à 13 rem, qui faisait déborder la
+     * page de trois pixels au départ.
+     *
+     * Entrer dedans efface ensuite Amis, le VR et l'avatar, donc il gagne
+     * encore leur place : rien à écrire pour cet état, il ne reste que lui.
+     *
+     * `:global()` parce que le champ appartient à la page : la barre lui
+     * prête sa place et décide donc de sa largeur, sans rien savoir
+     * d'autre de lui.
+     */
+    .page-tool :global(input[type='search']) {
+      flex: 1;
+      min-width: 0;
     }
 
     /* Amis passe à son icône, comme le VR. Le retour, lui, garde ses mots :
@@ -660,6 +664,7 @@
       display: block;
     }
 
+
     /* Et sur le peu qui reste : la barre se resserre. Mesuré à 416 px de
        contenu pour 390 de large sur /profile, où il n'y a rien à replier. */
     .top-bar {
@@ -671,16 +676,8 @@
       padding: 0.25rem 0.55rem;
     }
 
-    /* Dépliée, la recherche prend la barre : il n'y a pas de place pour
-       elle ET pour le reste, et la rétrécir jusqu'à ce que tout tienne la
-       rendrait inutilisable pour tout le monde. */
-    .top-bar.searching .page-tool {
-      display: contents;
-    }
-
     .top-bar.searching .left,
-    .top-bar.searching .right,
-    .top-bar.searching .search-toggle {
+    .top-bar.searching .right {
       display: none;
     }
 

--- a/frontend/src/lib/components/TopBar.svelte
+++ b/frontend/src/lib/components/TopBar.svelte
@@ -27,6 +27,22 @@
   const dispatch = createEventDispatcher<{ searchopen: void; searchclose: void }>();
 
   /*
+   * Le retour d'un écran qui possède son propre départ.
+   *
+   * `way-back.ts` tient la liste des écrans où rentrer est une navigation
+   * et rien d'autre, et exclut le salon : `releaseGame` y détache le jeu,
+   * rend le siège quand on est seul, et oublie le salon mémorisé avant de
+   * naviguer. Un `<a href="/">` dans la barre ne ferait rien de tout cela
+   * et ramènerait le joueur à la bibliothèque encore assis dans un salon
+   * que le serveur croit occupé - le mode de panne exact contre lequel ce
+   * module a été écrit.
+   *
+   * D'où cette prop plutôt qu'une entrée de plus dans la liste : la page
+   * prête son action, la barre ne fait que lui donner une place.
+   */
+  export let onBack: (() => void) | null = null;
+
+  /*
    * La recherche dépliée, et le reste de la barre effacé.
    *
    * Mesuré avant d'être décidé : le contenu de cette barre fait 393 px de
@@ -314,15 +330,53 @@
       d'un chemin de retour en ont un, nommé : `way-back.ts` dit lesquels
       et pourquoi le salon n'en fait pas partie.
     -->
-    {#if back}
+    {#if onBack}
       <!--
-        Said in words, and wearing the bar's own button shape: the whole finding
-        behind this is that a way back which has to be guessed at is not one.
-        The arrow is decoration next to the label, not a substitute for it.
+        Une flèche seule, à la demande du propriétaire, et sur les deux
+        écrans qui ont un retour.
+
+        Ce fichier portait la conclusion inverse : « un retour qu'il faut
+        deviner n'en est pas un », la flèche y étant une décoration à côté
+        du mot. Elle a été prise quand la marque était le seul autre chemin
+        et qu'elle ne se lisait pas comme tel. Depuis, la marque a disparu
+        et la gauche de la barre est vide : la flèche y est seule, à
+        l'endroit le plus conventionnel d'une interface, et non plus une
+        icône parmi d'autres qu'il faudrait distinguer. Le nom continue
+        d'être dit - infobulle et `aria-label` - et le salon garde en plus
+        son bouton nommé dans la page.
+
+        Ce qui reste non négociable est en dessous : la nature du contrôle.
       -->
-      <a class="bar-button back" href={back.href}>
-        <span aria-hidden="true">←</span>
-        {t($language, back.label)}
+      <button
+        class="bar-button back arrow"
+        on:click={onBack}
+        title={t($language, 'backToLibrary')}
+        aria-label={t($language, 'backToLibrary')}
+      >
+        <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor"
+             stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M10 2.5L4.5 8l5.5 5.5" />
+        </svg>
+      </button>
+    {:else if back}
+      <!--
+        La même flèche, et une balise différente - c'est tout ce qui sépare
+        les deux branches, et ce n'est pas cosmétique. Ici rentrer N'EST
+        qu'une navigation, donc un vrai lien : il s'ouvre dans un onglet,
+        se copie, se survole. Dans un salon ce serait un mensonge, et
+        `top-bar.spec.ts` épingle la distinction en regardant le nom de la
+        balise.
+      -->
+      <a
+        class="bar-button back arrow"
+        href={back.href}
+        title={t($language, back.label)}
+        aria-label={t($language, back.label)}
+      >
+        <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor"
+             stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M10 2.5L4.5 8l5.5 5.5" />
+        </svg>
       </a>
     {/if}
   </div>
@@ -479,8 +533,7 @@
    * du bouton, qui vient de `--btn-size`, donc changer l'un ne peut plus
    * désaccorder l'autre. La largeur se déduit du viewBox.
    */
-  .vr-glyph,
-  .friends-glyph,
+  .bar-button svg,
   .icon-button svg {
     height: 1.25em;
     width: auto;
@@ -566,14 +619,22 @@
     transform: translateY(1px);
   }
 
-  /* A link that has to read as a control, so it borrows the shape of the one
-     control the bar already had rather than introducing a second one. */
+  /* Un contrôle qui doit se lire comme tel, donc il emprunte la forme des
+     boutons de la barre plutôt que d'en introduire une seconde. */
   .back {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
     text-decoration: none;
     white-space: nowrap;
+  }
+
+  /* Une flèche n'a pas besoin de la largeur d'un mot - mais elle garde la
+     hauteur commune, donc seule la marge horizontale cède. Un raccourci
+     `padding` complet la rendrait plus courte que ses voisines, ce qui est
+     exactement la faute déjà corrigée deux fois dans cette barre. */
+  .back.arrow {
+    padding-inline: 0.55rem;
   }
 
   .friends-glyph {

--- a/frontend/src/lib/components/TopBar.svelte
+++ b/frontend/src/lib/components/TopBar.svelte
@@ -21,8 +21,41 @@
    * this bar. They are now a card mounted in the layout (`InvitationCard`), which
    * appears by itself wherever the player happens to be.
    */
-  import { onMount } from 'svelte';
+  import { onMount, createEventDispatcher } from 'svelte';
   import { page } from '$app/stores';
+
+  const dispatch = createEventDispatcher<{ searchopen: void; searchclose: void }>();
+
+  /*
+   * La recherche dépliée, et le reste de la barre effacé.
+   *
+   * Mesuré avant d'être décidé : le contenu de cette barre fait 393 px de
+   * large, donc sur un écran de 390 la page se met à défiler latéralement et
+   * la marque est rognée en un trait. Sous 480 px la recherche se replie donc
+   * en une loupe, et l'ouvrir efface Amis, le VR et l'avatar - il n'y a pas
+   * de place pour les deux, et « tout, en plus petit » n'existe pas ici.
+   *
+   * `searching` ne fait rien au-dessus du point de rupture : les règles qui
+   * le lisent vivent toutes dans la requête média, donc sur un large écran la
+   * barre reste ce qu'elle était, quoi que vaille ce drapeau.
+   */
+  let searching = false;
+
+  function openSearch() {
+    searching = true;
+    dispatch('searchopen');
+  }
+
+  /*
+   * Refermer efface la requête, et c'est la page qui s'en charge - la barre
+   * ne connaît pas le champ, elle ne fait que lui prêter sa place. Sans cet
+   * effacement la bibliothèque resterait filtrée sans que rien à l'écran ne
+   * dise pourquoi : un mode caché, et la pire sorte.
+   */
+  function closeSearch() {
+    searching = false;
+    dispatch('searchclose');
+  }
   import { user } from '$lib/stores/user';
   import { language } from '$lib/stores/language';
   import { t } from '$lib/i18n/translations';
@@ -240,7 +273,9 @@
   }
 </script>
 
-<header class="top-bar">
+<svelte:window on:keydown={(e) => { if (e.key === 'Escape' && searching) closeSearch(); }} />
+
+<header class="top-bar" class:searching>
   <div class="left">
     <!--
       The brand still goes home, because it always has and people who know that
@@ -292,17 +327,50 @@
     <slot name="tool" />
   </div>
 
+  {#if $$slots.tool}
+    <!-- Rendus seulement si la page a mis quelque chose à replier : sur
+         /profile et /docs il n'y a pas de recherche, donc pas de loupe.
+         Le CSS les cache au-dessus du point de rupture ; ils n'existent
+         que pour l'écran étroit. -->
+    <button class="icon-button search-toggle" on:click={openSearch} title={t($language, 'searchLibrary')} aria-label={t($language, 'searchLibrary')}>
+      <svg viewBox="0 0 16 16" width="17" height="17" fill="none" stroke="currentColor"
+           stroke-width="2" stroke-linecap="round" aria-hidden="true">
+        <circle cx="7" cy="7" r="4.5" />
+        <path d="M10.5 10.5L14 14" />
+      </svg>
+    </button>
+    <button class="icon-button search-close" on:click={closeSearch} title={t($language, 'close')} aria-label={t($language, 'close')}>
+      <svg viewBox="0 0 16 16" width="17" height="17" fill="none" stroke="currentColor"
+           stroke-width="2" stroke-linecap="round" aria-hidden="true">
+        <path d="M4 4L12 12M12 4L4 12" />
+      </svg>
+    </button>
+  {/if}
+
   <div class="right">
     {#if headsetHere}
       <!-- Capability, never a user agent: this button appears on a Quest and
            on a PC with a headset plugged in, and the "two controllers and
            nothing else" assumption only has to hold inside the session. -->
       <button
-        class="bar-button"
+        class="bar-button vr"
         title={t($language, 'vrSeatedTitle')}
+        aria-label={t($language, 'enterVr')}
         on:click={enterVr}
       >
-        {t($language, 'enterVr')}
+        <!-- Un cardboard dessiné, pas un emoji : sur une machine sans police
+             emoji un 🥽 rend un tofu, ce qui est arrivé ici. Deux oculaires
+             dans un boîtier, ce qui est ce qu'on reconnaît d'un casque à
+             cette taille. -->
+        <svg class="vr-glyph" viewBox="0 0 24 16" width="24" height="16" aria-hidden="true">
+          <rect x="0.9" y="1.9" width="22.2" height="12.2" rx="3.5"
+                fill="none" stroke="currentColor" stroke-width="1.8" />
+          <circle cx="7.4" cy="8" r="2.6" fill="currentColor" />
+          <circle cx="16.6" cy="8" r="2.6" fill="currentColor" />
+          <path d="M12 10.6c-0.7 0-1.1-0.5-1.1-1.3s0.4-1.3 1.1-1.3 1.1 0.5 1.1 1.3-0.4 1.3-1.1 1.3z"
+                fill="currentColor" />
+        </svg>
+        <span class="vr-label">{t($language, 'enterVr')}</span>
       </button>
       <!-- Beside the button, not under it: this bar is a centred flex row and a
            second line would change its height on every page. Only rendered
@@ -310,8 +378,23 @@
       <span class="vr-hint">{t($language, 'vrSeatedHint')}</span>
     {/if}
 
-    <button class="bar-button" class:on={showFriends} on:click={toggleFriends}>
-      {t($language, 'friends')}
+    <button
+      class="bar-button friends"
+      class:on={showFriends}
+      title={t($language, 'friends')}
+      aria-label={t($language, 'friends')}
+      on:click={toggleFriends}
+    >
+      <!-- Deux silhouettes, dessinées : c'est ce qu'on reconnaît d'une liste
+           d'amis à 17 px, et ça ne dépend d'aucune police installée. -->
+      <svg class="friends-glyph" viewBox="0 0 20 16" width="20" height="16"
+           fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"
+           aria-hidden="true">
+        <circle cx="7.5" cy="5" r="3" />
+        <path d="M1.8 14c0-2.8 2.5-4.6 5.7-4.6s5.7 1.8 5.7 4.6" />
+        <path d="M14 3.2a3 3 0 0 1 0 5.6M15.6 9.8c1.7.6 2.8 2 2.8 4" />
+      </svg>
+      <span class="friends-label">{t($language, 'friends')}</span>
     </button>
 
     <a class="avatar" href="/profile" title={$user?.pseudo ?? ''}>
@@ -352,6 +435,27 @@
   .page-tool {
     /* Ne prend de la place que si la page en met quelque chose. */
     display: contents;
+  }
+
+  /* La loupe et la croix n'existent que sur écran étroit : au-dessus du
+     point de rupture la recherche est dans la barre en permanence, et une
+     loupe qui l'ouvrirait n'ouvrirait rien. */
+  .icon-button {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 0.25rem 0.55rem;
+    background: var(--ground);
+    border: var(--btn-border) solid var(--edge);
+    box-shadow: var(--btn-bevel);
+    color: var(--shell);
+    border-radius: var(--btn-radius);
+    cursor: pointer;
+  }
+
+  .vr-glyph {
+    display: none;
   }
 
   .top-bar {
@@ -469,12 +573,16 @@
     white-space: nowrap;
   }
 
+  .friends-glyph {
+    display: none;
+  }
+
   .avatar {
     width: 2rem;
     height: 2rem;
     border-radius: 50%;
     overflow: hidden;
-    background: #333;
+    background: var(--ground);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -508,9 +616,76 @@
      the one that says where it goes: dropping the labelled link and keeping the
      logo would be exactly the bug this change exists to fix, on the screen size
      where it bites hardest. */
+  /*
+   * L'écran étroit, et le nombre vient d'une mesure : le contenu de cette
+   * barre fait 393 px, donc à 390 la page défile latéralement et la marque
+   * est rognée en un trait. 480 couvre ça, et c'est le point de rupture que
+   * ce fichier utilisait déjà - un troisième nombre n'apprendrait rien.
+   *
+   * La marque part en entier, et non plus seulement quand un retour la
+   * double : c'est le seul élément de la barre qui ne fasse rien qu'un
+   * autre ne fasse déjà.
+   */
   @media (max-width: 480px) {
-    .brand.redundant {
+    .brand {
       display: none;
+    }
+
+    /* Le VR garde son icône et perd son mot. */
+    .vr-label {
+      display: none;
+    }
+
+    .vr-glyph {
+      display: block;
+    }
+
+    .page-tool {
+      display: none;
+    }
+
+    .search-toggle {
+      display: inline-flex;
+    }
+
+    /* Amis passe à son icône, comme le VR. Le retour, lui, garde ses mots :
+       ce fichier porte la conclusion qu'un retour qu'il faut deviner n'en
+       est pas un, et la flèche y est une décoration à côté du mot, pas un
+       substitut. La place se prend donc ailleurs. */
+    .friends-label {
+      display: none;
+    }
+
+    .friends-glyph {
+      display: block;
+    }
+
+    /* Et sur le peu qui reste : la barre se resserre. Mesuré à 416 px de
+       contenu pour 390 de large sur /profile, où il n'y a rien à replier. */
+    .top-bar {
+      gap: 0.5rem;
+      padding: 0.5rem 0.6rem;
+    }
+
+    .bar-button {
+      padding: 0.25rem 0.55rem;
+    }
+
+    /* Dépliée, la recherche prend la barre : il n'y a pas de place pour
+       elle ET pour le reste, et la rétrécir jusqu'à ce que tout tienne la
+       rendrait inutilisable pour tout le monde. */
+    .top-bar.searching .page-tool {
+      display: contents;
+    }
+
+    .top-bar.searching .left,
+    .top-bar.searching .right,
+    .top-bar.searching .search-toggle {
+      display: none;
+    }
+
+    .top-bar.searching .search-close {
+      display: inline-flex;
     }
   }
 

--- a/frontend/src/lib/games/shelves.ts
+++ b/frontend/src/lib/games/shelves.ts
@@ -33,6 +33,22 @@ export function columnsThatFit(width: number, cardWidth: number, columnGap: numb
 	return Math.max(1, fits);
 }
 
+/**
+ * La largeur qu'une piste a vraiment, qui n'est pas toujours celle demandée.
+ *
+ * Le CSS la plafonne : `min(<largeur de carte>, 100%)`. Une jaquette de SNES
+ * garde son format et ne s'étire pas pour remplir un écran, mais elle ne
+ * peut pas non plus déborder d'un téléphone plus étroit qu'elle - alors elle
+ * cède. Les planches se posent donc sur cette largeur-ci, pas sur la valeur
+ * nominale, sans quoi elles traverseraient les jaquettes dès qu'elle cède.
+ *
+ * Le miroir exact de la fonction CSS, et c'est tout ce qu'elle est.
+ */
+export function trackWidth(width: number, cardWidth: number): number {
+	if (!(width > 0)) return 0;
+	return Math.min(cardWidth, width);
+}
+
 export interface RowLayout {
 	/** Combien de jaquettes la grille montre. */
 	count: number;

--- a/frontend/src/lib/nav/way-back.ts
+++ b/frontend/src/lib/nav/way-back.ts
@@ -18,8 +18,17 @@
 /** The label key, resolved by the caller through `t()`. */
 export type WayBack = { href: string; label: 'backToLibrary' };
 
-/** Screens where going home is plain navigation and nothing else. */
-const PLAIN_NAVIGATION = new Set(['/profile']);
+/**
+ * Screens where going home is plain navigation and nothing else.
+ *
+ * `/docs` joined the day the brand was removed from the bar. The comment
+ * above says the brand was the way home that nobody announced; with it gone,
+ * a reader of the documentation had no way back at all - not a convention
+ * that failed to read as one, simply nothing. The room still gets none, for
+ * the reason spelled out above: leaving one is an action that page owns, and
+ * it offers its own button for it.
+ */
+const PLAIN_NAVIGATION = new Set(['/profile', '/docs']);
 
 /** `/profile/` and `/profile` are the same screen; `/` stays `/`. */
 function normalise(pathname: string): string {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -283,9 +283,15 @@
 
     /* Les deux verbes du monde : le tuyau vert fait avancer, la carapace
        rouge annule. Chacun avec son ombre moulée d'un ton plus sombre. */
-    --go: #48a838;
+    /* Assombris par la mesure, pas au jugé. Les teintes de Super Mario World
+       telles quelles - #48A838 et #D84028 - donnent sous du blanc 3,03:1 et
+       4,48:1, là où AA demande 4,5 pour du texte normal. Comme ces deux
+       couleurs ne portent QUE des libellés blancs, c'est le libellé de
+       l'action principale de chaque écran qui passait sous le seuil. Même
+       teinte, descendue jusqu'à 4,73:1 et 5,57:1. */
+    --go: #2f8420;
     --go-deep: #1e5c18;
-    --stop: #d84028;
+    --stop: #c42f1c;
     --stop-deep: #7a1c10;
 
     /* Inchangés : la marque reste la cartouche de `icon.svg`, parce que

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { user, userLoading } from '$lib/stores/user';
   import { games, loadGames } from '$lib/stores/games';
   import type { Game } from '$lib/stores/games';
@@ -79,6 +79,21 @@
 
   /** Mesurée, pas devinée : c'est elle qui dit combien de jeux par rangée. */
   let gridWidth = 0;
+
+  /*
+   * Le champ de recherche, tenu pour pouvoir lui donner le focus.
+   *
+   * Sur écran étroit la barre replie la recherche derrière une loupe ; sans
+   * ce focus, l'ouvrir demanderait deux appuis - un pour déplier, un pour
+   * entrer dans le champ. `tick` parce que le champ n'est visible qu'après
+   * que Svelte a appliqué le changement d'état de la barre.
+   */
+  let searchInput: HTMLInputElement | null = null;
+
+  async function focusSearch() {
+    await tick();
+    searchInput?.focus();
+  }
 
   const SHELF_VARS = [
     `--card-w:${CARD_W}px`,
@@ -547,7 +562,10 @@
 {:else}
   <!-- Library page for authenticated users -->
   <div class="app-layout">
-    <TopBar>
+    <!-- Refermer la recherche efface la requête : la barre prête sa place au
+         champ mais ne le connaît pas, donc c'est ici que ça se passe. Sans
+         cela la bibliothèque resterait filtrée sans que rien ne dise pourquoi. -->
+    <TopBar on:searchopen={focusSearch} on:searchclose={() => (gameQuery = '')}>
       <!--
         Dans la barre plutôt que dans l'en-tête : elle est `sticky`, donc la
         recherche reste atteignable pendant tout le défilement d'une longue
@@ -563,6 +581,7 @@
           <input
             class="library-search"
             type="search"
+            bind:this={searchInput}
             bind:value={gameQuery}
             placeholder={t($language, 'searchLibrary')}
             aria-label={t($language, 'searchLibrary')}
@@ -1014,6 +1033,15 @@
     font-size: 1.1rem;
     min-width: 13rem;
     flex-shrink: 1;
+  }
+
+  /* Dépliée sur un écran étroit, elle a toute la barre : `min-width` doit
+     donc céder, sinon 13 rem la forceraient à déborder à nouveau. */
+  @media (max-width: 480px) {
+    .library-search {
+      flex: 1;
+      min-width: 0;
+    }
   }
 
   .library-search::placeholder {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -583,7 +583,6 @@
             type="search"
             bind:this={searchInput}
             bind:value={gameQuery}
-            placeholder={t($language, 'searchLibrary')}
             aria-label={t($language, 'searchLibrary')}
           />
         {/if}
@@ -1023,29 +1022,37 @@
   .library-search {
     appearance: none;
     -webkit-appearance: none;
-    background: var(--edge);
+    /*
+     * La loupe est dans le champ, pas à côté.
+     *
+     * Elle a d'abord été un bouton séparé qui faisait apparaître le champ ;
+     * c'était un objet de plus à comprendre pour ouvrir une chose qui
+     * pouvait rester là. Réduit à sa loupe sur un écran étroit, le champ
+     * est sa propre affordance. Le libellé « Chercher dans tes jeux » est
+     * parti avec elle : l'icône dit la même chose sans occuper de mot, et
+     * le nom reste dans `aria-label`, pour qui ne voit pas l'image.
+     *
+     * Un data URI plutôt qu'un fichier : trois cents octets ne méritent pas
+     * une requête. La couleur du trait est écrite dedans, parce qu'un fond
+     * SVG n'hérite pas de `currentColor`.
+     */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%238a6c00' stroke-width='2' stroke-linecap='round'%3E%3Ccircle cx='7' cy='7' r='4.5'/%3E%3Cpath d='M10.5 10.5L14 14'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: 0.55rem center;
+    background-size: 1rem;
+    background-color: var(--edge);
     color: #5a4400;
     border: 3px solid #ffffff;
     box-shadow: 0 0 0 3px var(--panel);
-    padding: 0.3rem 0.6rem;
+    /* La marge gauche est dans le raccourci, et pas à côté : déclarée
+       séparément AVANT lui, elle était remise à zéro par lui, et la loupe
+       se retrouvait sous le premier mot du libellé. */
+    padding: 0.3rem 0.6rem 0.3rem 2.1rem;
     border-radius: 0;
     font-family: var(--display);
     font-size: 1.1rem;
     min-width: 13rem;
     flex-shrink: 1;
-  }
-
-  /* Dépliée sur un écran étroit, elle a toute la barre : `min-width` doit
-     donc céder, sinon 13 rem la forceraient à déborder à nouveau. */
-  @media (max-width: 480px) {
-    .library-search {
-      flex: 1;
-      min-width: 0;
-    }
-  }
-
-  .library-search::placeholder {
-    color: #8a6c00;
   }
 
   .library-search:focus {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -38,7 +38,7 @@
   import LanguageSelector from '$lib/components/LanguageSelector.svelte';
   import TopBar from '$lib/components/TopBar.svelte';
   import SiteFooter from '$lib/components/SiteFooter.svelte';
-  import { columnsThatFit, rowBottoms } from '$lib/games/shelves';
+  import { columnsThatFit, rowBottoms, trackWidth } from '$lib/games/shelves';
   import { createLogger } from '$lib/utils/logger';
   import { setPageTitle } from '$lib/utils/page-title';
 
@@ -73,7 +73,7 @@
   /** Le ciel qui respire avant la rangée suivante. */
   const SKY = 12;
   /** `box-sizing: border-box` est global : la jaquette fait 0,7 fois sa largeur. */
-  const ROW_H = CARD_W * 0.7;
+  const COVER_RATIO = 0.7;
   /** Tout ce qui pend sous la ligne des cartouches. Le dessus arrière n'en est pas. */
   const SHELF_GAP = DECK_FRONT + LIP + CAST + SKY;
 
@@ -98,7 +98,6 @@
   const SHELF_VARS = [
     `--card-w:${CARD_W}px`,
     `--col-gap:${COL_GAP}px`,
-    `--row-h:${ROW_H}px`,
     `--shelf-gap:${SHELF_GAP}px`,
     `--deck-back:${DECK_BACK}px`,
     `--deck-front:${DECK_FRONT}px`,
@@ -291,10 +290,18 @@
    * mesurée - donc Svelte recalcule à l'ajout d'un jeu comme au
    * redimensionnement de la fenêtre.
    */
+  /*
+   * Tout se déduit de la piste RÉELLE, et non de sa largeur nominale.
+   *
+   * Le CSS la plafonne à la place disponible : sur un téléphone plus étroit
+   * qu'une jaquette, la carte cède. Calculer le pas sur 376 px dans ce cas
+   * poserait les planches au travers des images.
+   */
+  $: track = trackWidth(gridWidth, CARD_W);
   $: shelfTops = rowBottoms({
     count: shownGames.length,
-    columns: columnsThatFit(gridWidth, CARD_W, COL_GAP),
-    rowHeight: ROW_H,
+    columns: columnsThatFit(gridWidth, track, COL_GAP),
+    rowHeight: track * COVER_RATIO,
     rowGap: SHELF_GAP
   }).map(bottom => bottom - DECK_BACK);
 
@@ -1169,7 +1176,10 @@
     column-gap: var(--col-gap);
     row-gap: var(--shelf-gap);
     justify-content: center;
-    grid-auto-rows: var(--row-h);
+    /* `auto` plutôt qu'une hauteur écrite : la carte n'est qu'une jaquette,
+       donc sa hauteur EST sa largeur au format 10/7, et la rangée suit d'
+       elle-même quand la piste cède sur un écran étroit. */
+    grid-auto-rows: auto;
     /* La dernière planche pend sous la dernière rangée : sans cette
        réserve, elle passerait sur le pied de page. */
     padding-bottom: var(--shelf-gap);
@@ -1429,17 +1439,29 @@
     }
 
     .games-grid {
-      /* Une piste fluide n'a plus de hauteur prévisible, donc les planches
-         posées à un pas fixe dériveraient dans les cartes. Elles s'éteignent
-         ici plutôt que de traverser une jaquette. */
-      grid-template-columns: 1fr;
-      grid-auto-rows: auto;
-      gap: 1rem;
-      padding-bottom: 0;
-    }
-
-    .shelf {
-      display: none;
+      /*
+       * `min(...)` et non `1fr` : la jaquette garde son format, elle ne
+       * s'étire pas.
+       *
+       * `1fr` donnait une carte large comme son conteneur - près de 600 px
+       * sur une fenêtre de 700 - alors que la même jaquette fait 376 px
+       * juste au-dessus du point de rupture. Une boîte de SNES qui double
+       * de taille parce qu'on a rétréci la fenêtre est un accident, pas une
+       * adaptation. Le plafond la laisse à 376 partout où ça tient, et la
+       * réduit à la largeur disponible seulement quand il n'y a pas le
+       * choix.
+       *
+       * Une piste plafonnée n'a plus de hauteur prévisible dès qu'elle
+       * cède, donc les planches, posées à un pas fixe, dériveraient dans
+       * les cartes : elles s'éteignent ici plutôt que de traverser une
+       * jaquette.
+       */
+      grid-template-columns: repeat(auto-fill, min(var(--card-w), 100%));
+      /* Seule la gouttière horizontale se resserre : celle du bas tient les
+         étagères, qui restent tant que la piste est entière. C'est le JS qui
+         les retire quand elle ne l'est plus - `shelvesFit` - parce que c'est
+         lui qui sait la largeur mesurée. */
+      column-gap: 1rem;
     }
 
     .toast {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -875,14 +875,14 @@
     font-weight: 600;
   }
 
+  /* L'action de cet écran, donc verte. C'était le dégradé violet, qui ne
+     correspondait à aucune couleur de l'application. */
   .login-btn {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border: none;
-    padding: 1rem 2rem;
-    font-size: 1.125rem;
-    border-radius: 8px;
-    cursor: pointer;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
+    padding: 0.7rem 1.8rem;
+    font-size: 1.2rem;
     transition: transform 0.2s;
   }
 
@@ -1363,30 +1363,24 @@
     justify-content: flex-end;
   }
 
+  /* Renoncer n'est pas annuler une action déjà lancée : sombre et non
+     rouge, le rouge est réservé à ce qui détruit. */
   .btn-cancel {
-    background: rgba(68, 68, 68, 0.8);
-    color: white;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    padding: 0.75rem 1.5rem;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 1rem;
-    transition: all 0.2s;
+    padding: 0.55rem 1.4rem;
+    transition: background 0.2s;
   }
 
   .btn-cancel:hover {
-    background: rgba(88, 88, 88, 0.8);
+    background: var(--edge);
+    color: var(--panel);
   }
 
   .btn-confirm-delete {
-    background: linear-gradient(135deg, #f44336 0%, #d32f2f 100%);
-    color: white;
-    border: none;
-    padding: 0.75rem 1.5rem;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 1rem;
-    transition: all 0.2s;
+    background: var(--stop);
+    border-color: var(--stop-deep);
+    color: #ffffff;
+    padding: 0.55rem 1.4rem;
+    transition: background 0.2s;
   }
 
   .btn-confirm-delete:hover {

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -622,14 +622,12 @@
     color: #9fb4ff;
   }
 
+  /* Volontairement discret : c'est la doublure d'une valeur affichée juste
+     à côté, pas une action de la page. Il garde donc la forme commune et
+     seulement sa petite taille. */
   .copy {
-    padding: 0.2rem 0.6rem;
-    border: 1px solid #444;
-    border-radius: 6px;
-    background: transparent;
-    color: #ccc;
-    font-size: 0.72rem;
-    cursor: pointer;
+    padding: 0.1rem 0.6rem;
+    font-size: 0.85rem;
   }
 
   .copy:disabled {
@@ -671,16 +669,15 @@
     border-color: #b3564b;
   }
 
+  /* Enregistrer un pseudo fait avancer, donc vert - et le vert des jetons
+     est lui aussi descendu jusqu'au seuil de contraste, pour la même raison
+     qui avait fait assombrir le bleu qui était ici. */
   .rename-row button {
-    padding: 0 0.9rem;
-    border: 0;
-    border-radius: 6px;
-    /* Pas le #667eea de la marque : 3.66:1 sous du blanc, sous les 4.5
-       qu'AA demande. Même teinte, assombrie jusqu'à 4.96:1. */
-    background: #4764e6;
-    color: white;
-    font-size: 0.85rem;
-    cursor: pointer;
+    padding: 0.2rem 0.9rem;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
+    font-size: 0.95rem;
   }
 
   .rename-row button:disabled {
@@ -745,8 +742,11 @@
   }
 
   .shader.on {
-    background: rgba(102, 126, 234, 0.15);
-    border-color: #667eea;
+    /* Enfoncée, comme la touche du HUD : le biseau s'inverse et le libellé
+       passe à l'or. Le vert et le rouge restent des verbes. */
+    box-shadow: inset 0 4px 0 rgba(0, 0, 0, 0.4), inset 0 -4px 0 rgba(255, 255, 255, 0.08);
+    color: var(--edge);
+    transform: translateY(1px);
   }
 
   .shot {
@@ -770,25 +770,27 @@
     color: #fff;
   }
 
+  /* La forme vient du plancher. Cette règle la redéclarait, et comme elle
+     porte la classe de portée de Svelte elle gagnait : c'est ce qui laissait
+     « Importer un fichier » et ses voisins en gris plat. Il ne reste que la
+     transition, qui est propre à cette page. */
   button {
-    background: #333;
-    border: 2px solid transparent;
-    color: #fff;
-    padding: 0.45rem 0.8rem;
-    border-radius: 8px;
-    cursor: pointer;
     transition:
       background 0.15s,
       border-color 0.15s;
   }
 
   button:hover:not(:disabled) {
-    background: #3d3d3d;
+    background: var(--edge);
+    color: var(--panel);
   }
 
   button.on {
-    background: #3a4a5a;
-    border-color: #667eea;
+    /* Enfoncée, comme la touche du HUD : le biseau s'inverse et le libellé
+       passe à l'or. Le vert et le rouge restent des verbes. */
+    box-shadow: inset 0 4px 0 rgba(0, 0, 0, 0.4), inset 0 -4px 0 rgba(255, 255, 255, 0.08);
+    color: var(--edge);
+    transform: translateY(1px);
   }
 
   button:disabled {
@@ -812,16 +814,24 @@
   /* The file input itself is unstyleable across browsers, so the label is the
      control and the input is hidden inside it - clicking the label opens the
      picker, and keyboard focus still lands on the input. */
+  /* Un <label> qui enveloppe un `<input type="file">`, parce qu'un champ de
+     fichier ne se laisse pas habiller. Le plancher de `:global(button)` ne
+     l'atteint donc pas, et c'est exactement ce qui le laissait en gris plat
+     à côté d'un « Exporter » déjà refait : la recette est ici, tirée des
+     jetons. */
   .import {
     position: relative;
     overflow: hidden;
     display: inline-flex;
     align-items: center;
-    background: #333;
-    border: 2px solid transparent;
-    color: #fff;
-    padding: 0.45rem 0.8rem;
-    border-radius: 8px;
+    background: var(--panel);
+    border: var(--btn-border) solid var(--edge);
+    box-shadow: var(--btn-bevel);
+    color: var(--shell);
+    font-family: var(--display);
+    font-size: var(--btn-size);
+    padding: var(--btn-pad);
+    border-radius: var(--btn-radius);
     cursor: pointer;
     transition: background 0.15s;
   }
@@ -884,7 +894,8 @@
   }
 
   .logout {
-    background: #7f1d1d;
+    background: var(--stop);
+    border-color: var(--stop-deep);
   }
 
   .logout:hover:not(:disabled) {

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -571,6 +571,27 @@
     border-bottom: 1px solid rgba(255, 255, 255, 0.07);
   }
 
+  /* Sur un téléphone, l'avatar cède la moitié de la place qu'il prenait :
+     c'est une illustration, et ce qui se lit à côté ne l'est pas. */
+  @media (max-width: 480px) {
+    .identity {
+      gap: 1rem;
+    }
+
+    .avatar {
+      width: 4rem;
+      height: 4rem;
+    }
+  }
+
+  /* `min-width` vaut `auto` sur un élément flex, donc ce bloc refusait de
+     descendre sous sa largeur de contenu et poussait la page à déborder -
+     mesuré à 416 px de contenu pour 360 de large, et la même valeur à 320,
+     ce qui est la signature d'une largeur qui ne cède pas. */
+  .who {
+    min-width: 0;
+  }
+
   .avatar {
     width: 5.5rem;
     height: 5.5rem;

--- a/frontend/src/routes/room/[id]/+page.svelte
+++ b/frontend/src/routes/room/[id]/+page.svelte
@@ -1089,9 +1089,11 @@
   }
 
   .btn-setup.on {
-    background: #3a4a5a;
-    border-color: #667eea;
-    color: #fff;
+    /* Enfoncée, comme la touche du HUD : le biseau s'inverse et le libellé
+       passe à l'or. Le vert et le rouge restent des verbes. */
+    box-shadow: inset 0 4px 0 rgba(0, 0, 0, 0.4), inset 0 -4px 0 rgba(255, 255, 255, 0.08);
+    color: var(--edge);
+    transform: translateY(1px);
   }
 
   .panel {
@@ -1209,13 +1211,8 @@
 
   .btn-clear-save {
     flex-shrink: 0;
-    background: transparent;
-    color: #8ab4f8;
-    border: 1px solid #3d3d52;
-    border-radius: 6px;
-    padding: 0.3rem 0.7rem;
-    font-size: 0.8rem;
-    cursor: pointer;
+    padding: 0.15rem 0.7rem;
+    font-size: 0.9rem;
   }
 
   .btn-clear-save:hover {
@@ -1237,15 +1234,14 @@
     margin-top: 2rem;
   }
 
+  /* L'action du salon, et la plus verte de toutes : on lance la partie. */
   .btn-start {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border: none;
-    padding: 1rem 2rem;
-    font-size: 1.125rem;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.2s;
+    background: var(--go);
+    border-color: var(--go-deep);
+    color: #ffffff;
+    padding: 0.7rem 1.8rem;
+    font-size: 1.2rem;
+    transition: background 0.2s;
   }
 
   .btn-start:hover:not(:disabled) {
@@ -1253,11 +1249,10 @@
     box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
   }
 
+  /* Le plancher éteint déjà les boutons désactivés ; il ne reste que le
+     curseur, qui dit pourquoi le clic ne fait rien. */
   .btn-start:disabled {
-    background: #333;
-    color: #666;
     cursor: not-allowed;
-    opacity: 0.5;
   }
 
   /* Un <a>, que le plancher de `:global(button)` n'atteint pas : la

--- a/frontend/src/routes/room/[id]/+page.svelte
+++ b/frontend/src/routes/room/[id]/+page.svelte
@@ -786,7 +786,11 @@
 
        Retirée pour une session anonyme : elle porte la bibliothèque, les amis
        et le profil, dont aucune route ne lui répondra. -->
-  <TopBar />
+  <!-- La barre emprunte l'action de cette page : `releaseGame` rend le siège
+     et oublie le salon avant de naviguer, ce qu'un lien vers `/` ne ferait
+     pas. Voir la prop `onBack` de TopBar et l'exclusion du salon dans
+     `way-back.ts`. -->
+<TopBar onBack={releaseGame} />
 {/if}
 
 <div class="room-container">


### PR DESCRIPTION
Suite de la #55, qui avait harmonisé la forme des boutons. Ce lot finit le tour, corrige deux couleurs qui échouaient au contraste, et rend la barre utilisable sur un téléphone.

## Le tour complet des boutons

**38 règles dans 17 fichiers** étaient encore sur l'ancien langage. Trouvées en analysant les feuilles, pas en les lisant : l'analyseur retire les commentaires d'abord et compte les accolades, parce qu'un balayage naïf des boutons avait déjà menti deux fois sur ce dépôt (les `:` et `;` des commentaires cassent le découpage, les `@media` imbriqués aussi).

Trois espèces de survivants, chacune pour sa raison :

- Une règle `button` écrite **dans** un composant porte la classe de portée de Svelte, donc sa spécificité (0,1,1) bat celle du plancher (0,0,1) : elle gagnait en silence.
- **« Importer un fichier » est un `<label>`** qui enveloppe un champ de fichier — un `<input type="file">` ne se laisse pas habiller, et `:global(button)` ne l'atteint jamais.
- Les règles qui habillent aussi un `<select>` gardent leur recette, mais tirée des jetons.

## Un défaut mesuré : le contraste

Le blanc sur le vert de Super Mario World donne **3,03:1**, sur son rouge **4,48:1**, là où AA demande 4,5 pour du texte normal. Ces deux couleurs ne portent que des libellés blancs — donc c'était le libellé de l'action principale de chaque écran qui passait sous le seuil, **introduit par la #55 et déjà en production**. Mêmes teintes, descendues à 4,73:1 et 5,57:1.

## La barre sur un téléphone

Le contenu de la barre faisait 393 px : sur un écran de 390 la page défilait latéralement.

- **La marque disparaît**, à toutes les largeurs. Elle menait à la bibliothèque — une convention que le web honore sans l'annoncer, donc une affordance qui n'en avait pas l'air. `/docs` n'avait qu'elle : il entre dans la liste blanche de `way-back.ts` et reçoit un vrai retour.
- **Le VR est son icône partout**, un cardboard dessiné — pas un emoji, qui rend un tofu sans police système. « Se joue assis ou sur place » part avec le mot.
- **La loupe passe dans le champ.** Le champ ne disparaît jamais et prend toute la place que les autres laissent ; y entrer efface Amis, VR et l'avatar. Ouvrir se fait au `focusin`, fermer n'arrive que sur un champ vide — reprendre un filtre à quelqu'un qui vient de taper serait un vol, et laisser la barre dépliée sur un champ vide cache Amis pour rien.
- **La jaquette garde son format** sous 768 px au lieu de s'étirer à 600 px de large, et **les étagères restent à toutes les largeurs** : leur pas se déduit de la piste réellement mesurée.

## Le retour du salon, et ce qu'il ne doit pas être

`way-back.ts` exclut le salon exprès : en sortir détache le jeu, rend le siège et oublie le salon mémorisé. **Un `<a href="/">` dans la barre ramènerait le joueur à sa bibliothèque encore assis dans un salon que le serveur croit occupé.** La barre emprunte donc l'action de la page. `top-bar.spec.ts` épingle le **nom de la balise** : les deux mènent à `/`, un seul libère le siège.

Les deux retours sont réduits à une flèche, sur décision du propriétaire. Ce fichier portait la conclusion inverse ; elle avait été prise quand la marque était le seul autre chemin. La marque est partie, la gauche de la barre est vide, la flèche y est seule.

## Un débordement trouvé par la même mesure

`/profile` faisait 416 px à toutes les fenêtres, y compris 320 — la signature d'une largeur qui ne cède pas. `min-width` vaut `auto` sur un élément flex. Ce n'était pas la barre.

## Vérification

- `test:netplay` 130 · `test:core` 20 · `test:ui` **971 sur 74 fichiers** · `test:backend` 385
- e2e **55/55** sur base réinitialisée, dont deux specs neuves : `narrow-bar` (4 largeurs × 3 routes, plus le cycle complet de la recherche) et `top-bar`
- `svelte-check` 0 erreur, build frontend propre

Un test flottant est réparé au passage : `pseudo-gate` cliquait la connexion dev et naviguait sans l'attendre. Il a échoué deux fois en deux jours, toujours en affichant la page de connexion à `/profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)