### PR TITLE
Livrer le relief éteint, et l'allumer en une pression

### DIFF
--- a/core/test/vr-panel-relief.test.ts
+++ b/core/test/vr-panel-relief.test.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_RELIEF,
   RELIEF_DISTANCES,
   RELIEF_SPACINGS,
+  stepSpacing,
   type ReliefPreset
 } from '../../frontend/src/lib/vr/relief-preset.js';
 import { VR_SLOT_KEYS, type VrSlotKey } from '../../frontend/src/lib/vr/layer-map.js';
@@ -109,10 +110,23 @@ test('the strength row is there even when the frame has no layers to speak of', 
   // One flat plane is what a core with no layer plane gives, and the strength
   // is still the knob that says so. Losing it would leave a panel with a Back
   // button on it and nothing else.
+  //
+  // Only the « + » though: the preset ships at the bottom rung, so « − » is at
+  // the end of its ladder and is drawn without being aimable, which is the
+  // same rule every other row obeys.
   const list = ids({ preset: DEFAULT_RELIEF, slots: ['backdrop'] });
-  assert.ok(list.includes('spacing-less'));
+  assert.ok(!list.includes('spacing-less'), 'a butted step kept its target');
   assert.ok(list.includes('spacing-more'));
   assert.ok(list.includes('close'));
+});
+
+test('once the strength is off the floor, both of its steps answer', () => {
+  // The counterpart of the test above, and the one that would catch a panel
+  // that dropped « − » for good rather than only at the bottom of the ladder.
+  const raised = stepSpacing(DEFAULT_RELIEF, 1);
+  const list = ids({ preset: raised, slots: ['backdrop'] });
+  assert.ok(list.includes('spacing-less'));
+  assert.ok(list.includes('spacing-more'));
 });
 
 test('the order of the rows is the order the picture is stacked in', () => {

--- a/core/test/vr-relief-preset.test.ts
+++ b/core/test/vr-relief-preset.test.ts
@@ -275,7 +275,9 @@ test('spacing scales every distance, and zero flattens the picture', () => {
 test('listing walks every game, and skips entries it cannot read', () => {
   const store = storage();
   const mario = stepSlot(DEFAULT_RELIEF, 'sprite', 1);
-  const zelda = stepSpacing(DEFAULT_RELIEF, -1);
+  // Up, not down: the default ships at the bottom rung, so stepping down is a
+  // no-op and writing the default removes the key rather than storing it.
+  const zelda = stepSpacing(DEFAULT_RELIEF, 1);
   writeReliefPreset(store, MARIO, mario);
   writeReliefPreset(store, ZELDA, zelda);
   store.setItem('psnes-vr-screen', JSON.stringify({ distance: 2.5 }));

--- a/core/test/vr-slot-depth.test.ts
+++ b/core/test/vr-slot-depth.test.ts
@@ -29,6 +29,16 @@ type Key = (typeof VR_SLOT_KEYS)[number];
 
 const at = (depths: number[], key: Key) => depths[VR_SLOT_KEYS.indexOf(key)];
 
+/*
+ * The shipped preset with the strength turned up.
+ *
+ * The default ships at zero strength, so every slot resolves to the glass and
+ * nothing below would have anything to compare. What these tests are about is
+ * the ORDER the ladder puts the layers in, which only exists once a player has
+ * asked for relief - so they ask for it.
+ */
+const ON: ReliefPreset = { ...DEFAULT_RELIEF, spacing: 1 };
+
 /** The shipped preset with a few slots moved, and optionally a strength. */
 function preset(over: Partial<Record<Key, number>> = {}, spacing = 1): ReliefPreset {
   return { spacing, slots: { ...DEFAULT_RELIEF.slots, ...over } };
@@ -39,7 +49,9 @@ test('the answer is one offset per slot, in the order the mask is written in', (
   // entry i. A different length or a different order is a picture whose layers
   // are at each other's distances, which looks like the depths being wrong
   // rather than like an index being wrong.
-  const depths = slotDepths();
+  // At full strength a slot's depth IS its rung, so a misplaced entry shows up
+  // as a mismatched number rather than as ten zeroes agreeing with each other.
+  const depths = slotDepths(ON);
   assert.equal(depths.length, VR_SLOT_KEYS.length);
   for (const [index, key] of VR_SLOT_KEYS.entries()) {
     assert.equal(depths[index], DEFAULT_RELIEF.slots[key], `${key} is not at index ${index}`);
@@ -48,14 +60,31 @@ test('the answer is one offset per slot, in the order the mask is written in', (
 
 test('called with nothing, it is the shipped preset', () => {
   // The screen is built when the session opens and the game is chosen
-  // afterwards, so there is a window in which no preset has been read yet. It
-  // must be the default rather than a flat picture, or the relief would look
-  // like it only switches on when the settings panel is opened.
+  // afterwards, so there is a window in which no preset has been read yet.
   assert.deepEqual(slotDepths(), slotDepths(DEFAULT_RELIEF));
 });
 
-test('the default stack runs from the backdrop out to the sprites', () => {
-  const depths = slotDepths();
+test('the shipped default is flat, so no game changes on its own', () => {
+  /*
+   * Relief is a taste, not a correction - nobody's SNES had it. A picture that
+   * quietly stopped being flat would be a change made on the player's behalf,
+   * so the strength ships at its zero rung and every slot resolves to the
+   * glass until someone turns it up.
+   *
+   * The distances underneath are NOT zeroed with it, which is what the next
+   * test rests on: one press on the strength has to give the whole diorama,
+   * correctly proportioned, rather than a player building ten rows by hand
+   * before seeing anything.
+   */
+  for (const depth of slotDepths()) assert.equal(depth, 0);
+  assert.ok(
+    VR_SLOT_KEYS.some((key) => DEFAULT_RELIEF.slots[key]! > 0),
+    'the ladder must survive underneath the zero strength'
+  );
+});
+
+test('turned up, the stack runs from the backdrop out to the sprites', () => {
+  const depths = slotDepths(ON);
   assert.equal(at(depths, 'backdrop'), 0);
   assert.ok(at(depths, 'bg3.lo') > at(depths, 'backdrop'));
   assert.ok(at(depths, 'bg2.lo') > at(depths, 'bg3.lo'));
@@ -71,7 +100,7 @@ test('a status bar is painted on the glass, not floated in front of it', () => {
    * head moves, and - because a slot is only drawn where it won the pixel - it
    * cuts a glyph-shaped hole through everything behind it.
    */
-  const depths = slotDepths();
+  const depths = slotDepths(ON);
   assert.equal(at(depths, 'bg3.hi'), 0);
   assert.ok(at(depths, 'bg3.lo') > 0, 'the clouds and the status bar must not share a distance');
 });
@@ -80,7 +109,7 @@ test('the two halves of one background stay at one distance', () => {
   // High and low are two passes over the same scrolling surface. Splitting
   // them would tear one plane in half along whatever the artist gave priority
   // to. BG3 is the exception above, and only because the hardware flag says so.
-  const depths = slotDepths();
+  const depths = slotDepths(ON);
   assert.equal(at(depths, 'bg1.hi'), at(depths, 'bg1.lo'));
   assert.equal(at(depths, 'bg2.hi'), at(depths, 'bg2.lo'));
   assert.equal(at(depths, 'bg4.hi'), at(depths, 'bg4.lo'));

--- a/frontend/src/lib/vr/relief-preset.ts
+++ b/frontend/src/lib/vr/relief-preset.ts
@@ -135,8 +135,24 @@ const DEFAULT_SLOTS: Record<VrSlotKey, number> = {
 	sprite: 0.18
 };
 
+/**
+ * Off until asked for, and on in one press.
+ *
+ * The strength starts at its zero rung, so a game looks exactly as it did
+ * before this existed until the player goes and turns it on. Relief is a taste
+ * rather than a correction: nobody's SNES had it, and a picture that quietly
+ * stopped being flat is a change made on the player's behalf.
+ *
+ * The slot distances keep their values underneath rather than being zeroed
+ * with it, and that is the whole point of putting the strength in front of
+ * them. Zeroing the ten would leave a player who wants relief building the
+ * stack a rung at a time before seeing anything at all, and having to guess
+ * the proportions between backgrounds that the hardware already states. One
+ * press on the strength gives the whole diorama, correctly proportioned; the
+ * rows are there to disagree with it afterwards.
+ */
 export const DEFAULT_RELIEF: ReliefPreset = {
-	spacing: 1,
+	spacing: 0,
 	slots: DEFAULT_SLOTS
 };
 

--- a/tools/vr-relief/README.md
+++ b/tools/vr-relief/README.md
@@ -62,8 +62,20 @@ Trois choses se sont révélées non négociables, chacune après un faux dépar
 - **La priorité ne nomme pas un calque sans le mode BG.** En mode 1 BG1 vaut
   47/43 ; en mode 3, 43 est BG2. D'où `pn_depth_bg_mode()`.
 
-## Ce qui n'a pas été mesuré
+## Le coût dans le casque
 
-Le coût dans un casque. Rien ici n'a jamais tourné sur un Quest, et la page
-n'est pas un test de performance : elle affiche une frame figée. Six plans en
-plein écran avec du recouvrement, ce n'est pas six quads gratuits.
+La crainte était que dix plans en plein écran avec du recouvrement, chacun
+échantillonnant deux textures, ne tiennent pas la cadence. **Essayé sur un
+Quest en production le 2026-09-11 : la cadence tient.** C'est un constat du
+propriétaire du casque, pas un relevé chiffré — personne n'a lu un compteur
+de frames — mais c'en est un de première main, là où tout le reste de ce
+fichier vient d'une machine de bureau.
+
+L'optimisation qui était préparée n'a donc pas eu à être faite : ne créer que
+les plans réellement présents dans la frame plutôt que les dix. Un plan sur
+deux ne sert à rien dans un jeu donné, et `slot-mask.ts` renvoie déjà la
+liste dans `present`. Elle reste le premier levier si un jeu plus chargé fait
+céder la cadence un jour.
+
+La page, elle, ne dira jamais rien du coût : elle affiche une frame figée.
+


### PR DESCRIPTION
Le relief part désormais **éteint**. Un jeu a exactement l'apparence qu'il avait avant que tout ceci existe, jusqu'à ce que le joueur aille le demander. C'est un goût, pas une correction — aucune SNES n'avait ça — et une image qui cesse discrètement d'être plate est un changement décidé à la place du joueur.

## Éteint, mais allumé en une pression

Les dix distances par calque ne sont **pas** mises à zéro avec l'intensité, et c'est toute la raison pour laquelle l'intensité est placée devant elles. Les zéroter aussi obligerait celui qui veut du relief à reconstruire la pile cran par cran avant de voir quoi que ce soit, en devinant des proportions entre arrière-plans que le matériel énonce déjà.

Une pression sur « + » de l'intensité donne le diorama entier, correctement proportionné. Les rangées existent pour le contredire ensuite.

## Trois tests sont tombés, aucun n'était faux

Chacun décrivait l'ancien défaut, donc chacun a été **déplacé plutôt qu'affaibli**.

Ceux qui vérifiaient que la pile s'étale du fond aux sprites appelaient `slotDepths()` sans argument. Ils portent sur l'**ordre** que l'échelle impose, lequel n'existe qu'une fois le relief demandé — ils le demandent maintenant. Deux assertions ont été ajoutées plutôt que perdues : que le défaut livré ramène chaque calque sur la vitre, et que l'échelle survit sous l'intensité nulle. La seconde est précisément la propriété sur laquelle repose le « allumé en une pression ».

Un test écrivait un preset en descendant l'intensité d'un cran depuis 1. Le défaut étant le barreau du bas, c'est devenu sans effet — et écrire le défaut efface la clé au lieu de la stocker, donc l'énumération qu'il vérifiait revenait incomplète. Il monte d'un cran.

Le dernier affirmait que les deux pas de l'intensité sont visables. À zéro, le « − » est au bout de son échelle : dessiné, délibérément non visable, ce que toutes les autres rangées font déjà. Il est scindé en deux — un au plancher, un un cran plus haut — et le second attraperait un panneau qui perdrait « − » pour de bon.

## Le README de la sonde perd une affirmation devenue fausse

Il disait que rien n'avait jamais tourné sur un Quest. C'est fait, en production, et **la cadence tient**. Consigné pour ce que c'est : un constat de première main, pas un compteur que quelqu'un a lu. L'optimisation préparée au cas où elle ne tiendrait pas — ne créer que les plans réellement présents dans la frame — est signalée comme non nécessaire plutôt que supprimée, `slot-mask.ts` continuant de fournir la liste.

## Vérifications

`test:ui` 1049 passent, 1 ignoré, 0 échec. `tsc` inchangé (la seule erreur est préexistante, dans `+page.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
