### PR TITLE
Documenter la VR, et doubler la portée du relief

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -326,6 +326,91 @@ enregistrés par `index.ts` à chaque connexion authentifiée
   statut de présence (`user:{userId}:status`). C'est aussi la source dont
   `bootstrap/jobs.ts` restaure les rooms au redémarrage.
 
+## La VR : une présentation, pas un cinquième mode
+
+Le casque ne change rien à l'émulation. `VrShell.svelte` pilote les mêmes
+`createSoloEngine` et `createLockstepEngine` que `SoloRoom` et `LockstepRoom`,
+sur le même core wasm, et lancer un jeu à deux depuis la VR ouvre une room
+ordinaire que l'ami peut rejoindre à plat. Le tableau des quatre modes plus
+haut reste donc la bonne grille de lecture : la VR est une surface de sortie et
+d'entrée par-dessus, pas une cinquième ligne.
+
+Elle est montée une seule fois, dans `+layout.svelte`, au-dessus du `<slot />`
+— seul endroit présent quoi que fasse le joueur, et qu'une navigation ne
+démonte pas.
+
+**Le chemin d'entrée.** `support.ts` pose au navigateur la seule question
+honnête (`isSessionSupported`, jamais le user-agent). `prepare.ts` existe pour
+une loi empirique établie sur un vrai Quest 3 : **lire le dossier de ROMs
+depuis une session immersive ne marche jamais**, la permission accordée sur la
+page plate répondant « non accordée » une fois dans le casque. Les jeux sont
+donc rapatriés avant que le casque ne prenne la main, et `door.ts` demande la
+permission à la porte plutôt qu'au point d'usage — la boîte de dialogue native
+est dessinée par le navigateur, sur la page, c'est-à-dire exactement ce que le
+casque a remplacé. `xr-session.ts` ne demande que l'espace `local`, garanti par
+la spécification, et garantit qu'on ne sort qu'une fois.
+
+**La scène.** `scene.ts` détient le renderer et une seule politique : la boucle
+XR pompe le gouverneur puis rend. Elle ne décide jamais qu'une frame existe —
+c'est `FrameGovernor` qui le fait, à travers `frame-pump.ts`, et c'est ce qui
+tient l'émulateur à 60,0988 Hz sur un casque à 72 ou 90. `layout.ts` et
+`anchor.ts` concentrent toutes les distances et la position de la scène dans
+des modules qui n'importent pas three, donc testables sous Bun et réglables
+d'un seul fichier. `framebuffer-scale.ts` réclame la résolution native plutôt
+que celle que le runtime recommande avec un œil sur son propre budget.
+
+**Les panneaux.** Une session immersive n'a pas de DOM à réutiliser : un
+panneau est un canvas peint à la main plus une liste de rectangles
+(`panel.ts`, `panel-mesh.ts`). La mise en page est une fonction pure rendant
+des `Region[]`, donc testée sous Bun ; seuls les appels de dessin ne le sont
+pas. `panels/chrome.ts` porte l'habillage Super Mario World commun. Les menus
+d'options vivent sur une tablette flottante qui change de contenu plutôt que
+d'empiler des écrans. **Des crans, jamais de curseurs** : le pointeur est un
+laser tenu à bout de bras, viser un bouton est franc là où faire glisser une
+poignée ne l'est pas, et les bouts d'une échelle butent au lieu de boucler.
+
+**Les entrées.** `pad.ts` traduit deux manettes Touch en un masque SNES 12
+bits — les Touch parlent `xr-standard`, pas `standard`, et les axes n'ont pas
+le même sens. `bt-pad.ts` ajoute une manette Bluetooth **en plus** et non à la
+place. `pointer.ts` tient la détection de front sans laquelle une gâchette
+maintenue lancerait un jeu soixante-douze fois par seconde.
+
+### Le relief des calques
+
+Une frame SNES arrive plate, mais elle n'a pas été composée à plat : en
+dessinant, le PPU décide pour chaque pixel quel calque et quelle priorité l'ont
+emporté, et garde la réponse dans `GFX.ZBuffer`. Le core expose ce plan en
+lecture seule (`core/src/gfx_depth.cpp`, `pn_depth()`), et l'écran VR s'en sert
+pour séparer les calques dans l'espace : dix plans plats, un par couple
+(calque, priorité), chacun ne montrant que les pixels qu'il a gagnés.
+
+Quatre choses sont à savoir avant de toucher à ce chemin, chacune ayant d'abord
+produit une réponse plausible et fausse :
+
+- **Il faut lire les deux tampons de profondeur.** Beaucoup de jeux dessinent
+  l'essentiel de leurs calques sur le *sub-screen* et les ramènent par color
+  math ; `GFX.ZBuffer` seul rend un plan uniformément plat.
+- **libretro décale la frame de sept lignes** dans `GFX.Screen` (overscan).
+  `pn_depth()` retrouve le décalage depuis le pointeur qu'on lui passe.
+- **Un octet de priorité ne nomme pas un calque sans le mode BG** : en mode 1,
+  BG1 vaut 47/43 ; en mode 3, 43 est BG2. D'où `pn_depth_bg_mode()` et
+  `vr/layer-map.ts`.
+- **La distance appartient au couple, pas au calque.** Un calque peut être à
+  deux endroits : dans Super Mario All-Stars les nuages et la barre d'état sont
+  tous deux BG3, à deux priorités que le matériel compose aux deux extrémités
+  de l'ordre.
+
+Le réglage est retenu par jeu, sur l'appareil, sous la clé CRC32 de la ROM
+(`vr/relief-preset.ts`). Il part **éteint** : le relief est un goût, pas une
+correction, et une pression sur l'intensité donne le diorama entier,
+correctement proportionné.
+
+Ce qui n'est pas fait : les trous. Un calque n'est dessiné que là où il a gagné
+le pixel, donc ce qui est devant lui y laisse un trou, et rien dans la frame ne
+dit ce qu'il y avait derrière. Reboucher à 60 Hz n'est pas résolu. `tools/vr-relief/`
+garde la sonde qui a servi à établir tout ceci, avec le détail des trois
+approches pesées.
+
 ## Frontend : au-delà des modes
 
 **`frontend/src/lib/rooms/`** — logique partagée entre les composants de
@@ -362,7 +447,8 @@ psnes/
 ├── LOCKSTEP_NETPLAY.md      # référence netcode lockstep
 ├── README.md
 ├── core/                    # core wasm dédié au mode lockstep (snes9x + libretro frontend maison)
-│   └── src/psnes_core.c
+│   ├── src/psnes_core.c
+│   └── src/gfx_depth.cpp    # la seule fenêtre ouverte sur les internes de snes9x (lecture seule)
 ├── docs/
 │   ├── history/             # instantanés de travaux terminés (voir docs/history/README.md)
 │   ├── QUICKSTART.md
@@ -394,11 +480,14 @@ psnes/
 │       ├── netplay/                 # sync manager, rollback, buffers (mode dual)
 │       ├── webrtc/                   # p2p-manager.ts (signalisation + DataChannel)
 │       ├── emulator/                  # wrapper WasmEmulator, input-manager
+│       ├── vr/                          # session immersive : scène, écran, panneaux, manettes
+│       │   └── panels/                    # un panneau = un canvas peint + des Region[]
 │       └── api/, stores/, services/, config/, controls/, saves/, lobby/, games/, roms/, i18n/, utils/
 ├── e2e/                       # tests Playwright (dont probe-lockstep.mjs)
+├── tools/vr-relief/           # sonde du relief des calques (bun run vr:relief)
 └── scripts/                   # svelte-frozen-props.mjs, net-probe.sh, …
 ```
 
 ---
 
-**Dernière mise à jour :** 2026-08-26
+**Dernière mise à jour :** 2026-09-11

--- a/frontend/src/lib/vr/panels/relief.ts
+++ b/frontend/src/lib/vr/panels/relief.ts
@@ -244,7 +244,20 @@ export function layoutReliefPanel(state: ReliefPanelState): Region[] {
   return regions;
 }
 
-/** The position dots, centred under the value box. */
+/**
+ * The position dots, centred under the value box and sized to fit it.
+ *
+ * The size is derived rather than fixed because the ladder's length is not
+ * this module's to know: it lives in `relief-preset.ts`, it has already grown
+ * once, and a hard-coded dot size turns the next lengthening into a row of
+ * dots wider than the box it belongs to - a cosmetic fault nothing tests and
+ * nobody sees until a headset is on. Deriving it means the row fits by
+ * construction, whatever the ladder becomes.
+ *
+ * The floor is 4 px. Below that a dot stops reading as a filled position in a
+ * row of empty ones, which is the whole of what it has to say, and a ladder
+ * long enough to hit the floor wants rethinking rather than shrinking.
+ */
 function drawRungs(
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -252,11 +265,12 @@ function drawRungs(
   count: number,
   at: number
 ): void {
-  const span = count * DOT_SIZE + (count - 1) * DOT_GAP;
+  const size = Math.max(4, Math.min(DOT_SIZE, Math.floor((VALUE_W - (count - 1) * DOT_GAP) / count)));
+  const span = count * size + (count - 1) * DOT_GAP;
   const left = x + (VALUE_W - span) / 2;
   for (let i = 0; i < count; i++) {
     ctx.fillStyle = i === at ? SMW.accent : SMW.sandDark;
-    ctx.fillRect(left + i * (DOT_SIZE + DOT_GAP), y, DOT_SIZE, DOT_SIZE);
+    ctx.fillRect(left + i * (size + DOT_GAP), y, size, size);
   }
 }
 

--- a/frontend/src/lib/vr/relief-preset.ts
+++ b/frontend/src/lib/vr/relief-preset.ts
@@ -59,21 +59,30 @@ export interface ReliefPreset {
  * composited in: the sky would come out in front of the ground, and no setting
  * of the other nine slots could put it back.
  *
- * 30 cm is the top, and the ceiling is the occlusion holes rather than taste.
- * A layer is only drawn where it won the pixel, so everything in front of it
- * leaves a hole in it, and `tools/vr-relief` fills those holes by dilating the
- * layer into them because the frame does not record what was really behind.
- * The fill is a smear that stays hidden while the layer in front still covers
- * it. Past roughly 30 cm of separation it stops covering it as soon as the
- * player leans, and the smear is what they see through the gap.
+ * 60 cm is the top. The ladder used to stop at 30, and the reason written here
+ * was the dilation smear: `tools/vr-relief` fills a layer's occlusion holes by
+ * growing the layer into them, and that guess stays hidden only while the
+ * layer in front still covers it. The reasoning was sound and it was about the
+ * wrong renderer. The probe dilates; the screen does not. What ships draws
+ * each layer strictly where it won the pixel and leaves the holes open, so
+ * there is no smear to keep covered and the ceiling was paying for a cost this
+ * path does not have.
+ *
+ * What does bound it is the room. A slot's distance is multiplied by the
+ * strength, so the reach is the two together: 60 cm at 1.5 puts a plane 90 cm
+ * in front of the picture, and the nearest screen the player can choose sits
+ * at 2 m. That leaves the frontmost plane over a metre away, which is still a
+ * screen across the room rather than something in the face. Raising the
+ * strength's ceiling as well would compound with this one, and compounding two
+ * ladders is how a plane ends up behind the eyes.
  *
  * The rungs are finer near the bottom because that is where the effect is
  * decided: the first few centimetres are the difference between a flat picture
- * and a diorama, while the difference between 22 and 26 cm is a matter of
+ * and a diorama, while the difference between 44 and 52 cm is a matter of
  * degree.
  */
 export const RELIEF_DISTANCES: readonly number[] = [
-	0, 0.02, 0.05, 0.08, 0.1, 0.13, 0.15, 0.18, 0.22, 0.26, 0.3
+	0, 0.02, 0.05, 0.08, 0.1, 0.13, 0.15, 0.18, 0.22, 0.26, 0.3, 0.36, 0.44, 0.52, 0.6
 ];
 
 /**


### PR DESCRIPTION
Deux changements, séparés en deux commits.

## La VR entre dans ARCHITECTURE.md

Le document décrivait le produit par mode de room et datait du 26 août, avant tout le travail VR. **Il ne contenait pas le mot.** Un lecteur arrivant sur le dépôt y trouvait quatre modes, un serveur, une carte des répertoires, et aucune indication qu'une coquille immersive existe.

La section commence par ce que la VR **n'est pas** : un cinquième mode. `VrShell.svelte` pilote les mêmes `createSoloEngine` et `createLockstepEngine` que les rooms plates, sur le même core, et lancer un jeu à deux depuis le casque ouvre une room ordinaire que l'ami rejoint à plat. Vérifié dans les imports plutôt que supposé.

Le reste privilégie ce qu'une relecture du code ne redonnerait pas : la loi empirique de `prepare.ts` — lire le dossier de ROMs depuis une session immersive ne marche jamais, établie sur un vrai Quest 3 — ; pourquoi `layout.ts` et `anchor.ts` n'importent pas three ; pourquoi un panneau est un canvas peint ; des crans jamais de curseurs, avec la raison ; et pour le relief, les quatre pièges qui ont chacun produit une réponse plausible et fausse.

Deux corrections de cohérence non demandées mais sans lesquelles le document se contredit : `frontend/src/lib/vr/`, `tools/vr-relief/` et `core/src/gfx_depth.cpp` manquaient à la carte des répertoires, et la date annonçait août.

## L'échelle des distances va jusqu'à 60 cm

Elle plafonnait à 30, et **la justification écrite à côté portait sur le mauvais moteur de rendu**. Elle invoquait la bavure de dilatation : `tools/vr-relief` rebouche les trous d'occlusion d'un calque en l'étendant dedans, et cette devinette ne reste cachée que tant que le calque de devant la couvre.

Le raisonnement était juste. Seulement la sonde dilate, l'écran non : ce qui est livré dessine chaque calque strictement là où il a gagné le pixel et laisse les trous ouverts. Il n'y a donc aucune bavure à cacher, et le plafond payait un coût que ce chemin n'a pas.

Ce qui borne réellement, c'est la pièce, et l'en-tête le dit désormais à la place de l'ancienne raison. La distance est multipliée par l'intensité : 60 cm à 1,5 met un plan à 90 cm devant l'image, et l'écran le plus proche que le joueur peut choisir est à 2 m. **Le plafond de l'intensité est laissé tel quel, volontairement** — composer deux échelles est la façon dont un plan finit derrière les yeux.

Les pastilles de position sous chaque valeur étaient dimensionnées pour onze crans et quinze débordaient. Leur taille dérive maintenant du nombre de crans, plancher à 4 px : la rangée tient par construction et la prochaine rallonge ne pourra plus déborder en silence. Défaut cosmétique, visible seulement dans un casque, qu'aucun test ne voit — raison pour laquelle il valait mieux supprimer la classe que l'instance. Contrôlé en peignant le panneau hors casque à six et dix rangées.

## Vérifications

`test:ui` 1049 passent, 1 ignoré, 0 échec. `tsc` inchangé (seule erreur préexistante, dans `+page.ts`). `docs-content` passe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
